### PR TITLE
Bug fixes

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -143,15 +143,14 @@ cat <<'EOF' >> ~/cloudwatchlog.conf
 [/var/log/bastion]
 datetime_format = %b %d %H:%M:%S
 buffer_duration = 5000
-log_stream_name = bastion
+log_stream_name = {instance_id}
 initial_position = start_of_file
 EOF
 
-    export STREAM_NAME=`cat /etc/awslogs/awslogs.conf | grep ^log_stream_name | head -1`
-    export TMPGROUP=`cat /etc/awslogs/awslogs.conf | grep ^log_group_name`
-    export TMPGROUP=`echo $TMPGROUP | sed 's/\//\\\\\//g'`
-    sed -i.back "s/$STREAM_NAME/log_stream_name = messages/g" /etc/awslogs/awslogs.conf
-    sed -i.back "s/$TMPGROUP/log_group_name = $CWG/g" /etc/awslogs/awslogs.conf
+    LINE=$(cat -n /etc/awslogs/awslogs.conf | grep '\[\/var\/log\/messages\]' | awk {'print $1'})
+    END_LINE=$(echo $(($LINE-1)))
+    head -$END_LINE /etc/awslogs/awslogs.conf > /tmp/awslogs.conf
+    cat /tmp/awslogs.conf > /etc/awslogs/awslogs.conf
     cat ~/cloudwatchlog.conf >> /etc/awslogs/awslogs.conf
     cat /tmp/groupname.txt >> /etc/awslogs/awslogs.conf
     export TMPREGION=`cat /etc/awslogs/awscli.conf | grep region`
@@ -205,7 +204,7 @@ cat <<'EOF' >> ~/cloudwatchlog.conf
 state_file = /var/awslogs/state/agent-state
 
 [/var/log/bastion]
-log_stream_name = bastion
+log_stream_name = {instance_id}
 datetime_format = %b %d %H:%M:%S
 EOF
     export Region=`curl http://169.254.169.254/latest/meta-data/placement/availability-zone | rev | cut -c 2- | rev`
@@ -299,7 +298,7 @@ logging_config_file = /var/awslogs/etc/awslogs.conf
 datetime_format = %Y-%m-%d %H:%M:%S
 file = /var/log/messages
 buffer_duration = 5000
-log_stream_name = bastion
+log_stream_name = {instance_id}
 initial_position = start_of_file
 EOF
         export Region=`curl http://169.254.169.254/latest/meta-data/placement/availability-zone | rev | cut -c 2- | rev`
@@ -348,7 +347,7 @@ cat <<'EOF' >> ~/cloudwatchlog.conf
 [/var/log/bastion]
 datetime_format = %b %d %H:%M:%S
 buffer_duration = 5000
-log_stream_name = bastion
+log_stream_name = {instance_id}
 initial_position = start_of_file
 EOF
         export TMPGROUP=`cat /etc/awslogs/awslogs.conf | grep ^log_group_name`

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -106,7 +106,7 @@
             "Type": "String"
         },
         "BastionBanner": {
-            "Default": "https://s3.amazonaws.com/quickstart-reference/linux/bastion/latest/scripts/banner_message.txt",
+            "Default": "https://s3.amazonaws.com/quickstart-development-ianhill/linux/bastion/latest/scripts/banner_message.txt",
             "Description": "Banner text to display upon login",
             "Type": "String"
         },
@@ -182,7 +182,7 @@
         "QSS3BucketName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
             "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
-            "Default": "quickstart-reference",
+            "Default": "quickstart-development-ianhill",
             "Description": "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
             "Type": "String"
         },
@@ -468,7 +468,7 @@
                     }
                 ]
             }
-        },        
+        },
         "BastionHostRole": {
             "Type": "AWS::IAM::Role",
             "Properties": {
@@ -725,14 +725,15 @@
                             "",
                             [
                                 "#!/bin/bash\n",
-                                "PATH=$PATH:/usr/local/bin\n",
+                                "export PATH=$PATH:/usr/local/bin\n",
                                 "which pip &> /dev/null\n",
                                 "if [ $? -ne 0 ] ; then\n",
-                                "    [ `which yum` ] && $(yum install -y epel-release; yum install -y python-pip)\n",
+                                "echo \"PIP NOT INSTALLED\"\n",
+                                "    [ `which yum` ] && $(yum install -y epel-release; yum install -y python-pip) && echo \"PIP INSTALLED\"\n",
                                 "    [ `which apt-get` ] && apt-get -y update && apt-get -y install python-pip\n",
                                 "fi\n",
-                                "pip install --upgrade pip\n",
-                                "pip install awscli --ignore-installed six\n",
+                                "pip install --upgrade pip &> /dev/null\n",
+                                "pip install awscli --ignore-installed six &> /dev/null\n",
                                 "easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
                                 "EIP_LIST=\"",
                                 {

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -106,7 +106,7 @@
             "Type": "String"
         },
         "BastionBanner": {
-            "Default": "https://s3.amazonaws.com/quickstart-development-ianhill/linux/bastion/latest/scripts/banner_message.txt",
+            "Default": "https://s3.amazonaws.com/quickstart-reference/linux/bastion/latest/scripts/banner_message.txt",
             "Description": "Banner text to display upon login",
             "Type": "String"
         },
@@ -182,7 +182,7 @@
         "QSS3BucketName": {
             "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
             "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
-            "Default": "quickstart-development-ianhill",
+            "Default": "quickstart-reference",
             "Description": "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
             "Type": "String"
         },
@@ -728,9 +728,9 @@
                                 "export PATH=$PATH:/usr/local/bin\n",
                                 "which pip &> /dev/null\n",
                                 "if [ $? -ne 0 ] ; then\n",
-                                "echo \"PIP NOT INSTALLED\"\n",
+                                "    echo \"PIP NOT INSTALLED\"\n",
                                 "    [ `which yum` ] && $(yum install -y epel-release; yum install -y python-pip) && echo \"PIP INSTALLED\"\n",
-                                "    [ `which apt-get` ] && apt-get -y update && apt-get -y install python-pip\n",
+                                "    [ `which apt-get` ] && apt-get -y update && apt-get -y install python-pip && echo \"PIP INSTALLED\"\n",
                                 "fi\n",
                                 "pip install --upgrade pip &> /dev/null\n",
                                 "pip install awscli --ignore-installed six &> /dev/null\n",


### PR DESCRIPTION
AWSLogs now use the instance_id as the stream_name.
Removed /var/log/messages from AWSLogs config.
Updated PIP bootstrap.