### PR TITLE
Front service with ELB with scheduled instance rotation

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -466,7 +466,7 @@ function prevent_process_snooping() {
     echo "${FUNCNAME[0]} Ended"
 }
 
-function install_awscli_deps() {
+function install_awscli() {
     case $(osrelease) in
         "Ubuntu")
             ubuntu=`cat /etc/os-release | grep VERSION_ID | tr -d \VERSION_ID=\"`
@@ -509,7 +509,6 @@ function download_ssh_keys() {
 
 # So we don't get MITM attack warnings when connecting to different backend bastion hosts behind the ELB
 function sync_ssh_keys() {
-    install_awscli_deps
     if ssh_keys_not_present ; then
         # Return the name of the ASG of which this instance is a member
         ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --instance-ids $INSTANCE_ID | jq --raw-output '.AutoScalingInstances[].AutoScalingGroupName')
@@ -668,6 +667,7 @@ else
 fi
 
 prevent_process_snooping
+install_awscli
 
 # Deployed using EIP(s) or behind an ELB?
 if [ "${SSH_SERVER_CERT_BUCKET}" == "NO_S3_BUCKET_USED" ]; then

--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -27,6 +27,8 @@ function usage () {
     echo -e "--help \t Show options for this script"
     echo -e "--banner \t Enable or Disable Bastion Message"
     echo -e "--enable \t SSH Banner"
+    echo -e "--ssh-server-cert-bucket \t S3 bucket for SSH server certs"
+    echo -e "--stack-id \t ID used to track roles"
     echo -e "--tcp-forwarding \t Enable or Disable TCP Forwarding"
     echo -e "--x11-forwarding \t Enable or Disable X11 Forwarding"
 }
@@ -88,7 +90,7 @@ echo "$LOG_ORIGINAL_COMMAND" >> "${bastion_mnt}/${bastion_log}"
 log_dir="/var/log/bastion/"
 script -qf /tmp/messages --command=/bin/bash
 else
-# The "script" program could be circumvented with some commands 
+# The "script" program could be circumvented with some commands
 # (e.g. bash, nc). Therefore, I intentionally prevent users
 # from supplying commands.
 
@@ -398,7 +400,6 @@ function request_eip() {
 
         if [ "$AVAILABLE_EIPs" -gt "$ZERO" ]; then
             FIELD_COUNT="5"
-            INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
             echo "Running associate_eip_now"
             while read name;
             do
@@ -465,16 +466,90 @@ function prevent_process_snooping() {
     echo "${FUNCNAME[0]} Ended"
 }
 
+function install_awscli_deps() {
+    case $(osrelease) in
+        "Ubuntu")
+            ubuntu=`cat /etc/os-release | grep VERSION_ID | tr -d \VERSION_ID=\"`
+            if [ "$ubuntu" == "16.04" ]; then
+                pip install awscli
+            else
+                # Avoid a libyaml incompatibility problem with latest awscli in 14.04
+                pip install awscli==1.11.110
+            fi
+             apt-get install -y jq
+        ;;
+        "AMZN")
+            yum install -y jq
+        ;;
+        "CentOS")
+            pip install awscli
+            yum install -y jq
+        ;;
+    esac
+    aws configure set region $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | rev | cut -c 2- | rev)
+    echo "${FUNCNAME[0]} Ended"
+}
+
+function ssh_keys_not_present() {
+    return $(aws s3 ls s3://${SSH_SERVER_CERT_BUCKET}/ssh/ssh_host_rsa_key | wc -l)
+}
+
+function download_ssh_keys() {
+    rm -f /etc/ssh/ssh_host*
+    aws s3api wait object-exists --bucket ${SSH_SERVER_CERT_BUCKET} --key ssh/ssh_host_rsa_key
+    aws s3 sync s3://${SSH_SERVER_CERT_BUCKET}/ssh/ /etc/ssh/ --include 'ssh_host*'
+    find /etc/ssh -name "*key" -exec chmod 600 {} \;
+    if [ $(osrelease) == "Ubuntu" ]; then
+        service ssh restart
+    else
+        service sshd restart
+    fi
+    echo "${FUNCNAME[0]} Ended"
+}
+
+# So we don't get MITM attack warnings when connecting to different backend bastion hosts behind the ELB
+function sync_ssh_keys() {
+    install_awscli_deps
+    if ssh_keys_not_present ; then
+        # Return the name of the ASG of which this instance is a member
+        ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --instance-ids $INSTANCE_ID | jq --raw-output '.AutoScalingInstances[].AutoScalingGroupName')
+        # Get all the instances within the auto scaling group, sort and pick the first one
+        LEAD_BASTION=$(aws autoscaling describe-auto-scaling-instances | jq --raw-output --arg ASG_NAME $ASG_NAME '.AutoScalingInstances[] | select(.AutoScalingGroupName == $ASG_NAME).InstanceId' | sort | head -1)
+        if [ "$INSTANCE_ID" = "$LEAD_BASTION" ] ; then
+            aws s3 cp /etc/ssh/ s3://${SSH_SERVER_CERT_BUCKET}/ssh/ --recursive --exclude '*' --include '*key*'
+        else
+            download_ssh_keys
+        fi
+    else
+        download_ssh_keys
+    fi
+    echo "${FUNCNAME[0]} Ended"
+}
+
+# Drop down from a more privileged init role to one that can just push logs
+function swap_roles() {
+    ASSOCIATION_ID=$(aws ec2 describe-iam-instance-profile-associations \
+        --filters "Name=instance-id,Values=${INSTANCE_ID}" | jq --raw-output '.IamInstanceProfileAssociations[0].AssociationId')
+
+    INSTANCE_PROFILE=$(aws iam list-instance-profiles \
+        --path-prefix "/${STACK_ID}/bastion-host/" | jq --raw-output '.InstanceProfiles[0].InstanceProfileName')
+
+    aws ec2 replace-iam-instance-profile-association \
+        --association-id $ASSOCIATION_ID \
+        --iam-instance-profile Name=${INSTANCE_PROFILE}
+}
+
 ##################################### End Function Definitions
 
 # Call checkos to ensure platform is Linux
 checkos
 
-## set an initial value
+## set some initial values
 SSH_BANNER="LINUX BASTION"
+INSTANCE_ID=$(curl --silent http://169.254.169.254/latest/meta-data/instance-id)
 
 # Read the options from cli input
-TEMP=`getopt -o h:  --long help,banner:,enable:,tcp-forwarding:,x11-forwarding: -n $0 -- "$@"`
+TEMP=`getopt -o h:  --long help,banner:,enable:,tcp-forwarding:,ssh-server-cert-bucket:,stack-id:,x11-forwarding: -n $0 -- "$@"`
 eval set -- "$TEMP"
 
 
@@ -493,6 +568,14 @@ while true; do
             ;;
         --enable)
             ENABLE="$2";
+            shift 2
+            ;;
+        --ssh-server-cert-bucket)
+            SSH_SERVER_CERT_BUCKET="$2";
+            shift 2
+            ;;
+        --stack-id)
+            STACK_ID="$2";
             shift 2
             ;;
         --tcp-forwarding)
@@ -586,6 +669,13 @@ fi
 
 prevent_process_snooping
 
-call_request_eip
+# Deployed using EIP(s) or behind an ELB?
+if [ "${SSH_SERVER_CERT_BUCKET}" == "NO_S3_BUCKET_USED" ]; then
+    call_request_eip
+else
+    sync_ssh_keys
+fi
+
+swap_roles
 
 echo "Bootstrap complete."

--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -30,6 +30,16 @@
                 },
                 {
                     "Label": {
+                        "default": "Elastic Load Balancing Configuration"
+                    },
+                    "Parameters": [
+                        "UseELB",
+                        "ELBRotationScheduleUp",
+                        "ELBRotationScheduleDown",
+                    ]
+                },
+                {
+                    "Label": {
                         "default": "Linux Bastion Configuration"
                     },
                     "Parameters": [
@@ -56,6 +66,15 @@
                 },
                 "BastionAMIOS": {
                     "default": "Bastion AMI Operating System"
+                },
+                "UseELB": {
+                    "default": "Elastic Load Balancing"
+                },
+                "ELBRotationScheduleUp": {
+                    "default": "Rotation Start"
+                },
+                "ELBRotationScheduleDown": {
+                    "default": "Rotation Finsh"
                 },
                 "BastionBanner": {
                     "default": "Bastion Banner"
@@ -144,6 +163,25 @@
                 "m4.2xlarge",
                 "m4.4xlarge"
             ]
+        },
+        "UseELB": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "false",
+            "Description": "ELB provides single name but multiple IPs. EIPs will be used if false",
+            "Type": "String"
+        },
+        "ELBRotationScheduleUp": {
+            "Default": "",
+            "Description": "Cron schedule to add an additional bastion to start a rotation event",
+            "Type": "String"
+        },
+        "ELBRotationScheduleDown": {
+            "Default": "",
+            "Description": "Cron schedule to add an additional bastion to complete a rotation event",
+            "Type": "String"
         },
         "EnableBanner": {
             "AllowedValues": [
@@ -371,6 +409,15 @@
                             "VPCStack",
                             "Outputs.VPCID"
                         ]
+                    },
+                    "UseELB": {
+                        "Ref": "UseELB"
+                    },
+                    "ELBRotationScheduleUp": {
+                        "Ref": "ELBRotationScheduleUp"
+                    },
+                    "ELBRotationScheduleDown": {
+                        "Ref": "ELBRotationScheduleDown"
                     }
                 }
             }

--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -180,7 +180,7 @@
         },
         "ELBRotationScheduleDown": {
             "Default": "",
-            "Description": "Cron schedule to add an additional bastion to complete a rotation event",
+            "Description": "Cron schedule to remove a bastion to complete a rotation event",
             "Type": "String"
         },
         "EnableBanner": {

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -164,7 +164,7 @@
         },
         "ELBRotationScheduleDown": {
             "Default": "",
-            "Description": "Cron schedule to add an additional bastion to complete a rotation event",
+            "Description": "Cron schedule to remove a bastion to complete a rotation event",
             "Type": "String"
         },
         "EnableBanner": {
@@ -833,68 +833,23 @@
                 "LoadBalancerPort": "22",
                 "Protocol": "TCP",
                 "InstanceProtocol": "TCP"
-              },
-              {
-                "InstancePort": "22",
-                "LoadBalancerPort": "443",
-                "Protocol": "TCP",
-                "InstanceProtocol": "TCP"
               }
             ]
           }
         },
         "BastionAutoScalingGroup": {
             "Type": "AWS::AutoScaling::AutoScalingGroup",
-            "Condition": "UseElasticIPs",
-            "Properties": {
-                "LaunchConfigurationName": {
-                    "Ref": "BastionLaunchConfiguration"
-                },
-                "VPCZoneIdentifier": [
-                    {
-                        "Ref": "PublicSubnet1ID"
-                    },
-                    {
-                        "Ref": "PublicSubnet2ID"
-                    }
-                ],
-                "MinSize": {
-                    "Ref": "NumBastionHosts"
-                },
-                "MaxSize": {
-                    "Ref": "NumBastionHosts"
-                },
-                "Cooldown": "300",
-                "DesiredCapacity": {
-                    "Ref": "NumBastionHosts"
-                },
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "Value": "LinuxBastion",
-                        "PropagateAtLaunch": "true"
-                    }
-                ]
-            },
-            "CreationPolicy": {
-                "ResourceSignal": {
-                    "Count": {
-                        "Ref": "NumBastionHosts"
-                    },
-                    "Timeout": "PT30M"
-                }
-            }
-        },
-        "BastionELBAutoScalingGroup": {
-            "Type": "AWS::AutoScaling::AutoScalingGroup",
-            "Condition": "UseElasticLoadBalancer",
             "Properties": {
                 "LaunchConfigurationName": {
                     "Ref": "BastionLaunchConfiguration"
                 },
                 "LoadBalancerNames": [
                     {
-                        "Ref": "BastionLoadBalancer"
+                        "Fn::If": [
+                            "UseElasticLoadBalancer",
+                            { "Ref": "BastionLoadBalancer" },
+                            { "Ref" : "AWS::NoValue" }
+                        ]
                     }
                 ],
                 "VPCZoneIdentifier": [
@@ -940,7 +895,7 @@
             "Condition": "UseELBScheduledRotation",
             "Properties": {
                 "AutoScalingGroupName": {
-                    "Ref": "BastionELBAutoScalingGroup"
+                    "Ref": "BastionAutoScalingGroup"
                 },
                 "MaxSize": { "Fn::FindInMap" : [ "AdditionHack", { "Ref" : "NumBastionHosts" }, "AddOne" ] },
                 "MinSize": { "Fn::FindInMap" : [ "AdditionHack", { "Ref" : "NumBastionHosts" }, "AddOne" ] },
@@ -952,7 +907,7 @@
             "Condition": "UseELBScheduledRotation",
             "Properties": {
                 "AutoScalingGroupName": {
-                    "Ref": "BastionELBAutoScalingGroup"
+                    "Ref": "BastionAutoScalingGroup"
                 },
                 "MaxSize": { "Ref" : "NumBastionHosts" },
                 "MinSize": { "Ref" : "NumBastionHosts" },
@@ -1072,11 +1027,7 @@
                 },
                 "SecurityGroups": [
                     {
-                      "Fn::If": [
-                          "UseElasticIPs",
-                          { "Ref": "BastionEIPSecurityGroup" },
-                          { "Ref": "BastionELBSecurityGroup" }
-                      ]
+                      "Ref": "BastionSecurityGroup"
                     }
                 ],
                 "InstanceType": {
@@ -1157,12 +1108,7 @@
                                 {
                                     "Ref": "AWS::StackName"
                                 },
-                                " --resource ",
-                                {
-                                  "Fn::If": [
-                                    "UseElasticIPs", "BastionAutoScalingGroup", "BastionELBAutoScalingGroup"
-                                  ]
-                                },
+                                " --resource BastionAutoScalingGroup",
                                 " --region ",
                                 {
                                     "Ref": "AWS::Region"
@@ -1174,9 +1120,8 @@
                 }
             }
         },
-        "BastionEIPSecurityGroup": {
+        "BastionSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
-            "Condition": "UseElasticIPs",
             "Properties": {
                 "GroupDescription": "Enables SSH Access to Bastion Hosts",
                 "VpcId": {
@@ -1188,26 +1133,38 @@
                         "FromPort": "22",
                         "ToPort": "22",
                         "CidrIp": {
-                            "Ref": "RemoteAccessCIDR"
+                            "Fn::If": [
+                                "UseElasticIPs",
+                                { "Ref": "RemoteAccessCIDR" },
+                                { "Ref" : "AWS::NoValue" }
+                            ]
+                        },
+                        "SourceSecurityGroupId": {
+                            "Fn::If": [
+                                "UseElasticLoadBalancer",
+                                { "Fn::GetAtt" : ["ELBSecurityGroup", "GroupId"] },
+                                { "Ref" : "AWS::NoValue" }
+                            ]
                         }
-                    }
-                ]
-            }
-        },
-        "BastionELBSecurityGroup": {
-            "Type": "AWS::EC2::SecurityGroup",
-            "Condition": "UseElasticLoadBalancer",
-            "Properties": {
-                "GroupDescription": "Enables SSH Access to Bastion Hosts",
-                "VpcId": {
-                    "Ref": "VPCID"
-                },
-                "SecurityGroupIngress": [
+                    },
                     {
-                      "IpProtocol": "tcp",
-                      "FromPort": "22",
-                      "ToPort": "22",
-                      "SourceSecurityGroupId": {"Fn::GetAtt" : ["ELBSecurityGroup", "GroupId"]}
+                        "IpProtocol": "icmp",
+                        "FromPort": "-1",
+                        "ToPort": "-1",
+                        "CidrIp": {
+                            "Fn::If": [
+                                "UseElasticIPs",
+                                { "Ref": "RemoteAccessCIDR" },
+                                { "Ref" : "AWS::NoValue" }
+                            ]
+                        },
+                        "SourceSecurityGroupId": {
+                            "Fn::If": [
+                                "UseElasticLoadBalancer",
+                                { "Fn::GetAtt" : ["ELBSecurityGroup", "GroupId"] },
+                                { "Ref" : "AWS::NoValue" }
+                            ]
+                        }
                     }
                 ]
             }
@@ -1228,14 +1185,6 @@
                         "CidrIp": {
                             "Ref": "RemoteAccessCIDR"
                         }
-                    },
-                    {
-                        "IpProtocol": "tcp",
-                        "FromPort": "443",
-                        "ToPort": "443",
-                        "CidrIp": {
-                            "Ref": "RemoteAccessCIDR"
-                        }
                     }
                 ]
             }
@@ -1248,6 +1197,12 @@
              "Value": {
                  "Fn::GetAtt": [ "BastionLoadBalancer", "DNSName" ]
              }
+         },
+         "BastionAutoScalingGroup": {
+             "Description": "Auto Scaling Group Reference ID",
+             "Value": {
+                "Ref": "BastionAutoScalingGroup"
+              }
          },
         "EIP1": {
             "Description": "Elastic IP 1 for Bastion",
@@ -1282,6 +1237,12 @@
                 "Ref": "BastionMainLogGroup"
             },
             "Description": "CloudWatch Logs GroupName. Your SSH logs will be stored here."
+        },
+        "BastionSecurityGroupID": {
+            "Value": {
+                "Ref": "BastionSecurityGroup"
+            },
+            "Description": "Bastion Security Group ID"
         }
     }
 }

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -27,6 +27,16 @@
                 },
                 {
                     "Label": {
+                        "default": "Elastic Load Balancing Configuration"
+                    },
+                    "Parameters": [
+                        "UseELB",
+                        "ELBRotationScheduleUp",
+                        "ELBRotationScheduleDown",
+                    ]
+                },
+                {
+                    "Label": {
                         "default": "Linux Bastion Configuration"
                     },
                     "Parameters": [
@@ -50,6 +60,15 @@
             "ParameterLabels": {
                 "BastionAMIOS": {
                     "default": "Bastion AMI Operating System"
+                },
+                "UseELB": {
+                    "default": "Elastic Load Balancing"
+                },
+                "ELBRotationScheduleUp": {
+                    "default": "Rotation Start"
+                },
+                "ELBRotationScheduleDown": {
+                    "default": "Rotation Finsh"
                 },
                 "BastionBanner": {
                     "default": "Bastion Banner"
@@ -127,6 +146,25 @@
             ],
             "Default": "t2.micro",
             "Description": "Amazon EC2 instance type for the bastion instances",
+            "Type": "String"
+        },
+        "UseELB": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "false",
+            "Description": "ELB provides single name but multiple IPs. EIPs will be used if false",
+            "Type": "String"
+        },
+        "ELBRotationScheduleUp": {
+            "Default": "",
+            "Description": "Cron schedule to add an additional bastion to start a rotation event",
+            "Type": "String"
+        },
+        "ELBRotationScheduleDown": {
+            "Default": "",
+            "Description": "Cron schedule to add an additional bastion to complete a rotation event",
             "Type": "String"
         },
         "EnableBanner": {
@@ -332,56 +370,58 @@
             "Ubuntu-Server-16.04-LTS-HVM": {
                 "Code": "US1604HVM"
             }
+        },
+        "AdditionHack" : {
+            "1" : {"AddOne" : "2"},
+            "2" : {"AddOne" : "3"},
+            "3" : {"AddOne" : "4"},
+            "4" : {"AddOne" : "5"}
         }
     },
     "Conditions": {
         "2BastionCondition": {
-            "Fn::Or": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "NumBastionHosts"
-                        },
-                        "2"
-                    ]
-                },
-                {
-                    "Condition": "3BastionCondition"
-                },
-                {
-                    "Condition": "4BastionCondition"
-                }
+            "Fn::And": [
+              {"Condition": "UseElasticIPs"},
+              {
+                "Fn::Or": [
+                  {"Fn::Equals": [{"Ref": "NumBastionHosts"},"2"]},
+                  {"Condition": "3BastionCondition"},
+                  {"Condition": "4BastionCondition"}
+                ]
+              }
             ]
         },
         "3BastionCondition": {
-            "Fn::Or": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "NumBastionHosts"
-                        },
-                        "3"
-                    ]
-                },
-                {
-                    "Condition": "4BastionCondition"
-                }
+            "Fn::And": [
+              {"Condition": "UseElasticIPs"},
+              {
+                "Fn::Or": [
+                  {"Fn::Equals": [{"Ref": "NumBastionHosts"},"3"]},
+                  {"Condition": "4BastionCondition"}
+                ]
+              }
             ]
         },
         "4BastionCondition": {
-            "Fn::Equals": [
-                {
-                    "Ref": "NumBastionHosts"
-                },
-                "4"
+            "Fn::And": [
+              {"Condition": "UseElasticIPs"},
+              {"Fn::Equals": [{"Ref": "NumBastionHosts"},"4"]}
             ]
         },
         "GovCloudCondition": {
-            "Fn::Equals": [
-                {
-                    "Ref": "AWS::Region"
-                },
-                "us-gov-west-1"
+            "Fn::Equals": [{"Ref": "AWS::Region"},"us-gov-west-1"]
+        },
+        "UseElasticLoadBalancer": {
+            "Fn::Equals": [{"Ref": "UseELB"},"true"]
+        },
+        "UseElasticIPs": {
+            "Fn::Equals": [{"Ref": "UseELB"},"false"]
+        },
+        "UseELBScheduledRotation": {
+            "Fn::And": [
+              { "Fn::Equals": [{"Ref": "UseELB"},"true"] },
+              { "Fn::Not": ["Fn::Equals": [{"Ref": "ELBRotationScheduleUp"}, ""]] },
+              { "Fn::Not": ["Fn::Equals": [{"Ref": "ELBRotationScheduleDown"}, ""]] }
             ]
         }
     },
@@ -415,9 +455,118 @@
                 ]
             }
         },
-        "BastionHostRole": {
-            "Type": "AWS::IAM::Role",
+        "QuickStartS3Policy": {
+           "Type": "AWS::IAM::ManagedPolicy",
+           "Properties" : {
+              "PolicyDocument" : {
+                 "Version": "2012-10-17",
+                "Statement": [
+                   {
+                       "Action": [ "s3:GetObject" ],
+                       "Resource": {
+                           "Fn::Sub": [
+                               "arn:${Partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*",
+                               {
+                                   "Partition": {
+                                       "Fn::If": [
+                                           "GovCloudCondition",
+                                           "aws-us-gov",
+                                           "aws"
+                                       ]
+                                   }
+                               }
+                           ]
+                       },
+                       "Effect": "Allow"
+                   }
+               ]
+              }
+           }
+        },
+        "InstanceRoleDiscoveryPolicy": {
+            "Type": "AWS::IAM::ManagedPolicy",
             "Properties": {
+               "PolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                      {
+                        "Action": [
+                            "autoscaling:DescribeAutoScalingInstances",
+                            "ec2:ReplaceIamInstanceProfileAssociation",
+                            "ec2:DescribeIamInstanceProfileAssociations",
+                            "iam:ListInstanceProfiles"
+                        ],
+                        "Resource": [
+                            "*"
+                        ],
+                        "Effect": "Allow"
+                      }
+                  ]
+              }
+            }
+         },
+         "SwapRolePolicy": {
+            "Type": "AWS::IAM::ManagedPolicy",
+            "Properties": {
+               "PolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                      {
+                        "Action": "iam:PassRole",
+                        "Resource": {"Fn::GetAtt" : ["BastionHostRole", "Arn"] },
+                        "Effect": "Allow"
+                      }
+                  ]
+              }
+            }
+         },
+        "CloudWatchLogsPolicy": {
+            "Type": "AWS::IAM::ManagedPolicy",
+            "Properties": {
+               "PolicyDocument": {
+                  "Version": "2012-10-17",
+                  "Statement": [
+                      {
+                        "Action": [
+                            "logs:CreateLogStream",
+                            "logs:GetLogEvents",
+                            "logs:PutLogEvents",
+                            "logs:DescribeLogGroups",
+                            "logs:DescribeLogStreams",
+                            "logs:PutRetentionPolicy",
+                            "logs:PutMetricFilter",
+                            "logs:CreateLogGroup"
+                        ],
+                        "Resource": {
+                            "Fn::Sub": [
+                                "arn:${Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${BastionMainLogGroup}:*",
+                                {
+                                    "Partition": {
+                                        "Fn::If": [
+                                            "GovCloudCondition",
+                                            "aws-us-gov",
+                                            "aws"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "Effect": "Allow"
+                      }
+                  ]
+              }
+            }
+         },
+        "BastionHostEIPInitRole": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "UseElasticIPs",
+            "Properties": {
+                "ManagedPolicyArns": [
+                  { "Ref": "CloudWatchLogsPolicy" },
+                  { "Ref": "QuickStartS3Policy" },
+                  { "Ref": "SwapRolePolicy" },
+                  { "Ref": "InstanceRoleDiscoveryPolicy" }
+                ],
                 "Policies": [
                     {
                         "PolicyDocument": {
@@ -446,41 +595,6 @@
                             ]
                         },
                         "PolicyName": "aws-quick-start-s3-policy"
-                    },
-                    {
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "logs:CreateLogStream",
-                                        "logs:GetLogEvents",
-                                        "logs:PutLogEvents",
-                                        "logs:DescribeLogGroups",
-                                        "logs:DescribeLogStreams",
-                                        "logs:PutRetentionPolicy",
-                                        "logs:PutMetricFilter",
-                                        "logs:CreateLogGroup"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Sub": [
-                                            "arn:${Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${BastionMainLogGroup}:*",
-                                            {
-                                                "Partition": {
-                                                    "Fn::If": [
-                                                        "GovCloudCondition",
-                                                        "aws-us-gov",
-                                                        "aws"
-                                                    ]
-                                                }
-                                            }
-                                        ]
-                                    },
-                                    "Effect": "Allow"
-                                }
-                            ]
-                        },
-                        "PolicyName": "bastion-cloudwatch-logs-policy"
                     },
                     {
                         "PolicyDocument": {
@@ -520,6 +634,134 @@
                 }
             }
         },
+        "BastionHostELBInitRole": {
+            "Type": "AWS::IAM::Role",
+            "Condition": "UseElasticLoadBalancer",
+            "Properties": {
+                "ManagedPolicyArns": [
+                  { "Ref": "CloudWatchLogsPolicy" },
+                  { "Ref": "QuickStartS3Policy" },
+                  { "Ref": "SwapRolePolicy" },
+                  { "Ref": "InstanceRoleDiscoveryPolicy" }
+                ],
+                "Policies": [
+                    {
+                      "PolicyDocument": {
+                          "Version": "2012-10-17",
+                          "Statement": [
+                              {
+                                  "Action": [
+                                      "s3:ListBucket"
+                                  ],
+                                  "Resource": {
+                                      "Fn::Sub": [
+                                          "arn:${Partition}:s3:::${SSHServerCertBucket}",
+                                          {
+                                              "Partition": {
+                                                  "Fn::If": [
+                                                      "GovCloudCondition",
+                                                      "aws-us-gov",
+                                                      "aws"
+                                                  ]
+                                              }
+                                          }
+                                      ]
+                                  },
+                                  "Effect": "Allow"
+                              }
+                          ]
+                      },
+                      "PolicyName": "list-cert-bucket"
+                  },
+                  {
+                      "PolicyDocument": {
+                          "Version": "2012-10-17",
+                          "Statement": [
+                              {
+                                  "Action": [
+                                      "s3:GetObject",
+                                      "s3:PutObject"
+                                  ],
+                                  "Resource": {
+                                      "Fn::Sub": [
+                                          "arn:${Partition}:s3:::${SSHServerCertBucket}/*",
+                                          {
+                                              "Partition": {
+                                                  "Fn::If": [
+                                                      "GovCloudCondition",
+                                                      "aws-us-gov",
+                                                      "aws"
+                                                  ]
+                                              }
+                                          }
+                                      ]
+                                  },
+                                  "Effect": "Allow"
+                              }
+                          ]
+                      },
+                      "PolicyName": "update-cert-bucket"
+                  },
+                ],
+                "Path": "/",
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            },
+                            "Effect": "Allow"
+                        }
+                    ],
+                    "Version": "2012-10-17"
+                }
+            }
+        },
+        "BastionHostInitProfile": {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Roles": [
+                    {
+                      "Fn::If": [
+                          "UseElasticIPs",
+                          { "Ref": "BastionHostEIPInitRole" },
+                          { "Ref": "BastionHostELBInitRole" }
+                      ]
+                    }
+                ],
+                "Path": "/"
+            }
+        },
+        "BastionHostRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "ManagedPolicyArns": [
+                  { "Ref": "CloudWatchLogsPolicy" }
+                ],
+                "Path": "/",
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Action": [
+                                "sts:AssumeRole"
+                            ],
+                            "Principal": {
+                                "Service": [
+                                    "ec2.amazonaws.com"
+                                ]
+                            },
+                            "Effect": "Allow"
+                        }
+                    ],
+                    "Version": "2012-10-17"
+                }
+            }
+        },
         "BastionHostProfile": {
             "Type": "AWS::IAM::InstanceProfile",
             "Properties": {
@@ -528,11 +770,12 @@
                         "Ref": "BastionHostRole"
                     }
                 ],
-                "Path": "/"
+                "Path": { "Fn::Sub": "/${AWS::StackId}/bastion-host/" }
             }
         },
         "EIP1": {
             "Type": "AWS::EC2::EIP",
+            "Condition": "UseElasticIPs",
             "Properties": {
                 "Domain": "vpc"
             }
@@ -558,8 +801,51 @@
                 "Domain": "vpc"
             }
         },
+        "SSHServerCertBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Condition": "UseElasticLoadBalancer",
+            "DeletionPolicy": "Retain"
+        },
+        "BastionLoadBalancer": {
+          "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+          "Condition": "UseElasticLoadBalancer",
+          "Properties": {
+            "CrossZone": "true",
+            "ConnectionSettings": {
+              "IdleTimeout": "75"
+            },
+            "Subnets": [
+              {
+                "Ref": "PublicSubnet1ID"
+              },
+              {
+                "Ref": "PublicSubnet2ID"
+              }
+            ],
+            "SecurityGroups": [
+              {
+                "Ref": "ELBSecurityGroup"
+              }
+            ],
+            "Listeners": [
+              {
+                "InstancePort": "22",
+                "LoadBalancerPort": "22",
+                "Protocol": "TCP",
+                "InstanceProtocol": "TCP"
+              },
+              {
+                "InstancePort": "22",
+                "LoadBalancerPort": "443",
+                "Protocol": "TCP",
+                "InstanceProtocol": "TCP"
+              }
+            ]
+          }
+        },
         "BastionAutoScalingGroup": {
             "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "Condition": "UseElasticIPs",
             "Properties": {
                 "LaunchConfigurationName": {
                     "Ref": "BastionLaunchConfiguration"
@@ -599,6 +885,80 @@
                 }
             }
         },
+        "BastionELBAutoScalingGroup": {
+            "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "Condition": "UseElasticLoadBalancer",
+            "Properties": {
+                "LaunchConfigurationName": {
+                    "Ref": "BastionLaunchConfiguration"
+                },
+                "LoadBalancerNames": [
+                    {
+                        "Ref": "BastionLoadBalancer"
+                    }
+                ],
+                "VPCZoneIdentifier": [
+                    {
+                        "Ref": "PublicSubnet1ID"
+                    },
+                    {
+                        "Ref": "PublicSubnet2ID"
+                    }
+                ],
+                "MinSize": {
+                    "Ref": "NumBastionHosts"
+                },
+                "MaxSize": {
+                    "Ref": "NumBastionHosts"
+                },
+                "Cooldown": "300",
+                "DesiredCapacity": {
+                    "Ref": "NumBastionHosts"
+                },
+                "TerminationPolicies": [
+                    "OldestInstance"
+                ],
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "LinuxBastion",
+                        "PropagateAtLaunch": "true"
+                    }
+                ]
+            },
+            "CreationPolicy": {
+                "ResourceSignal": {
+                    "Count": {
+                        "Ref": "NumBastionHosts"
+                    },
+                    "Timeout": "PT30M"
+                }
+            }
+        },
+        "ScheduledActionUp": {
+            "Type": "AWS::AutoScaling::ScheduledAction",
+            "Condition": "UseELBScheduledRotation",
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "BastionELBAutoScalingGroup"
+                },
+                "MaxSize": { "Fn::FindInMap" : [ "AdditionHack", { "Ref" : "NumBastionHosts" }, "AddOne" ] },
+                "MinSize": { "Fn::FindInMap" : [ "AdditionHack", { "Ref" : "NumBastionHosts" }, "AddOne" ] },
+                "Recurrence": { "Ref": "ELBRotationScheduleUp" }
+            }
+        },
+        "ScheduledActionDown": {
+            "Type": "AWS::AutoScaling::ScheduledAction",
+            "Condition": "UseELBScheduledRotation",
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "BastionELBAutoScalingGroup"
+                },
+                "MaxSize": { "Ref" : "NumBastionHosts" },
+                "MinSize": { "Ref" : "NumBastionHosts" },
+                "Recurrence": { "Ref": "ELBRotationScheduleDown" }
+            }
+        },
         "BastionLaunchConfiguration": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
             "Metadata": {
@@ -606,7 +966,11 @@
                     "S3AccessCreds": {
                         "type": "S3",
                         "roleName": {
-                            "Ref": "BastionHostRole"
+                          "Fn::If": [
+                              "UseElasticIPs",
+                              { "Ref": "BastionHostEIPInitRole" },
+                              { "Ref": "BastionHostELBInitRole" }
+                          ]
                         },
                         "buckets": [
                             {
@@ -654,6 +1018,18 @@
                                             {
                                                 "Ref": "EnableBanner"
                                             },
+                                            " --ssh-server-cert-bucket ",
+                                            {
+                                              "Fn::If": [
+                                                "UseElasticLoadBalancer",
+                                                {"Ref": "SSHServerCertBucket"},
+                                                "NO_S3_BUCKET_USED"
+                                              ]
+                                            },
+                                            " --stack-id ",
+                                            {
+                                                "Ref": "AWS::StackId"
+                                            },
                                             " --tcp-forwarding ",
                                             {
                                                 "Ref": "EnableTCPForwarding"
@@ -675,7 +1051,7 @@
                     "Ref": "KeyPairName"
                 },
                 "IamInstanceProfile": {
-                    "Ref": "BastionHostProfile"
+                    "Ref": "BastionHostInitProfile"
                 },
                 "ImageId": {
                     "Fn::FindInMap": [
@@ -696,7 +1072,11 @@
                 },
                 "SecurityGroups": [
                     {
-                        "Ref": "BastionSecurityGroup"
+                      "Fn::If": [
+                          "UseElasticIPs",
+                          { "Ref": "BastionEIPSecurityGroup" },
+                          { "Ref": "BastionELBSecurityGroup" }
+                      ]
                     }
                 ],
                 "InstanceType": {
@@ -720,7 +1100,13 @@
                                 "easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz\n",
                                 "EIP_LIST=\"",
                                 {
-                                    "Ref": "EIP1"
+                                    "Fn::If": [
+                                        "UseElasticIPs",
+                                        {
+                                            "Ref": "EIP1"
+                                        },
+                                        "Null"
+                                    ]
                                 },
                                 ",",
                                 {
@@ -771,7 +1157,13 @@
                                 {
                                     "Ref": "AWS::StackName"
                                 },
-                                " --resource BastionAutoScalingGroup --region ",
+                                " --resource ",
+                                {
+                                  "Fn::If": [
+                                    "UseElasticIPs", "BastionAutoScalingGroup", "BastionELBAutoScalingGroup"
+                                  ]
+                                },
+                                " --region ",
                                 {
                                     "Ref": "AWS::Region"
                                 },
@@ -782,8 +1174,9 @@
                 }
             }
         },
-        "BastionSecurityGroup": {
+        "BastionEIPSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
+            "Condition": "UseElasticIPs",
             "Properties": {
                 "GroupDescription": "Enables SSH Access to Bastion Hosts",
                 "VpcId": {
@@ -797,11 +1190,49 @@
                         "CidrIp": {
                             "Ref": "RemoteAccessCIDR"
                         }
+                    }
+                ]
+            }
+        },
+        "BastionELBSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Condition": "UseElasticLoadBalancer",
+            "Properties": {
+                "GroupDescription": "Enables SSH Access to Bastion Hosts",
+                "VpcId": {
+                    "Ref": "VPCID"
+                },
+                "SecurityGroupIngress": [
+                    {
+                      "IpProtocol": "tcp",
+                      "FromPort": "22",
+                      "ToPort": "22",
+                      "SourceSecurityGroupId": {"Fn::GetAtt" : ["ELBSecurityGroup", "GroupId"]}
+                    }
+                ]
+            }
+        },
+        "ELBSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Condition": "UseElasticLoadBalancer",
+            "Properties": {
+                "GroupDescription": "Enables SSH Access to ELB",
+                "VpcId": {
+                    "Ref": "VPCID"
+                },
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": "22",
+                        "ToPort": "22",
+                        "CidrIp": {
+                            "Ref": "RemoteAccessCIDR"
+                        }
                     },
                     {
-                        "IpProtocol": "icmp",
-                        "FromPort": "-1",
-                        "ToPort": "-1",
+                        "IpProtocol": "tcp",
+                        "FromPort": "443",
+                        "ToPort": "443",
                         "CidrIp": {
                             "Ref": "RemoteAccessCIDR"
                         }
@@ -811,14 +1242,16 @@
         }
     },
     "Outputs": {
-        "BastionAutoScalingGroup": {
-            "Description": "Auto Scaling Group Reference ID",
-            "Value": {
-                "Ref": "BastionAutoScalingGroup"
-            }
-        },
+        "LoadBalancerDNSName": {
+             "Description": "THe DNS name of the load balancer",
+             "Condition": "UseElasticLoadBalancer",
+             "Value": {
+                 "Fn::GetAtt": [ "BastionLoadBalancer", "DNSName" ]
+             }
+         },
         "EIP1": {
             "Description": "Elastic IP 1 for Bastion",
+            "Condition": "UseElasticIPs",
             "Value": {
                 "Ref": "EIP1"
             }
@@ -849,12 +1282,6 @@
                 "Ref": "BastionMainLogGroup"
             },
             "Description": "CloudWatch Logs GroupName. Your SSH logs will be stored here."
-        },
-        "BastionSecurityGroupID": {
-            "Value": {
-                "Ref": "BastionSecurityGroup"
-            },
-            "Description": "Bastion Security Group ID"
         }
     }
 }


### PR DESCRIPTION
**Use case:** Development account where many developers access via the bastion. 

**Additional Features:**
* Single named point of entry _bastion.projectX.mycompany.com_
  * Server certs are synced using a private S3 bucket
* Auto rotation of bastion instances using ASG ScheduledActions
  * Example is excessively fast just to demonstrate but Recurrence would become a parameter
  * Additional level of difficulty to maintain a entry point if bastion becomes compromised

**Cons**
* S3 bucket read/write in BastionHostRole increases exposure of server certs to users with local accounts.

I realize this probably isn't a common enough use case to merge this into the quickstart repo but if you have any feedback at all about the implementation I'd be really interested to hear your thoughts.