### PR TITLE
Match the tabs surrounding the IP address

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -384,7 +384,7 @@ function request_eip() {
     ALLOC=1
     ZERO=0
     INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-    ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
+    ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $'\\t'${INSTANCE_IP}$'\\t' | wc -l)
     if [ "$ASSIGNED" -gt "$ZERO" ]; then
         echo "Already assigned an EIP."
     else
@@ -432,7 +432,7 @@ function request_eip() {
         fi
 
         INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-        ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
+        ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $'\\t'${INSTANCE_IP}$'\\t' | wc -l)
         if [ "$ASSIGNED" -eq 1 ]; then
             echo "EIP successfully assigned."
         else
@@ -442,7 +442,7 @@ function request_eip() {
                 sleep 3
                 request_eip
                 INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-                ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
+                ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $'\\t'${INSTANCE_IP}$'\\t' | wc -l)
             done
         fi
     fi
@@ -458,7 +458,7 @@ function _query_public_v4_ips() {
 function call_request_eip() {
     ZERO=0
     INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-    ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
+    ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $'\\t'${INSTANCE_IP}$'\\t' | wc -l)
     if [ "$ASSIGNED" -gt 0 ]; then
         echo "Already assigned an EIP."
     else


### PR DESCRIPTION
When running describe-addresses, if a different address existed which
had the same string prefix as the instance's IP, it would fail stating
that the EIP was already bound. This adds a boundary around the search
for the IP to ensure that it is a complete match.

As an example, my instance came up with the local IP `10.200.0.4`, but an instance with `10.200.0.40` was in the same VPC. Because `grep` matched on this, the bootstrap script assumed it already had its EIP.