### PR TITLE
Adding zero hosts as option.

### DIFF
--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -307,7 +307,20 @@
             "DependsOn": "VPCStack",
             "Type": "AWS::CloudFormation::Stack",
             "Properties": {
-                "TemplateURL": "https://s3-us-west-2.amazonaws.com/bastion-aws-test/linux-bastion.template",
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/linux-bastion.template",
+                            {
+                            "QSS3Region": {
+                                "Fn::If": [
+                                        "GovCloudCondition",
+                                        "s3-us-gov-west-1",
+                                        "s3"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
                 "Parameters": {
                     "BastionAMIOS": {
                         "Ref": "BastionAMIOS"

--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -178,6 +178,7 @@
         },
         "NumBastionHosts": {
             "AllowedValues": [
+                "0",
                 "1",
                 "2",
                 "3",
@@ -306,20 +307,7 @@
             "DependsOn": "VPCStack",
             "Type": "AWS::CloudFormation::Stack",
             "Properties": {
-                "TemplateURL": {
-                    "Fn::Sub": [
-                        "https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/linux-bastion.template",
-                        {
-                            "QSS3Region": {
-                                "Fn::If": [
-                                    "GovCloudCondition",
-                                    "s3-us-gov-west-1",
-                                    "s3"
-                                ]
-                            }
-                        }
-                    ]
-                },
+                "TemplateURL": "https://s3-us-west-2.amazonaws.com/bastion-aws-test/linux-bastion.template",
                 "Parameters": {
                     "BastionAMIOS": {
                         "Ref": "BastionAMIOS"

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -162,6 +162,7 @@
         },
         "NumBastionHosts": {
             "AllowedValues": [
+                "0",
                 "1",
                 "2",
                 "3",
@@ -335,6 +336,27 @@
         }
     },
     "Conditions": {
+        "1BastionCondition": {
+            "Fn::Or": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "NumBastionHosts"
+                        },
+                        "1"
+                    ]
+                },
+                {
+                    "Condition": "2BastionCondition"
+                },
+                {
+                    "Condition": "3BastionCondition"
+                },
+                {
+                    "Condition": "4BastionCondition"
+                }
+            ]
+        },
         "2BastionCondition": {
             "Fn::Or": [
                 {
@@ -533,6 +555,7 @@
         },
         "EIP1": {
             "Type": "AWS::EC2::EIP",
+            "Condition": "1BastionCondition",
             "Properties": {
                 "Domain": "vpc"
             }
@@ -560,6 +583,7 @@
         },
         "BastionAutoScalingGroup": {
             "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "Condition":"1BastionCondition",
             "Properties": {
                 "LaunchConfigurationName": {
                     "Ref": "BastionLaunchConfiguration"
@@ -601,6 +625,7 @@
         },
         "BastionLaunchConfiguration": {
             "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "Condition":"1BastionCondition",
             "Metadata": {
                 "AWS::CloudFormation::Authentication": {
                     "S3AccessCreds": {
@@ -812,12 +837,14 @@
     },
     "Outputs": {
         "BastionAutoScalingGroup": {
+            "Condition": "1BastionCondition",
             "Description": "Auto Scaling Group Reference ID",
             "Value": {
                 "Ref": "BastionAutoScalingGroup"
             }
         },
         "EIP1": {
+            "Condition": "1BastionCondition",
             "Description": "Elastic IP 1 for Bastion",
             "Value": {
                 "Ref": "EIP1"


### PR DESCRIPTION
Adding zero hosts as an option. This feature allows a scale back approach for Production by keeping costs down (or a company has a no-ssh access policy). If/when ssh access is required we can still scale out by adding a host, login, debug and fix, then logout and scale in.