### PR TITLE
Update Ubuntu 16.04 AMIs

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -238,85 +238,85 @@
                 "AMZNLINUXHVM": "ami-33c25b55",
                 "CENTOS7HVM": "ami-4dd5522b",
                 "US1404HVM": "ami-fae6649c",
-                "US1604HVM": "ami-42ca4724"
+                "US1604HVM": "ami-d39a02b5"
             },
             "ap-northeast-2": {
                 "AMZNLINUXHVM": "ami-d9b616b7",
                 "CENTOS7HVM": "ami-53a1073d",
                 "US1404HVM": "ami-5451f73a",
-                "US1604HVM": "ami-5027813e"
+                "US1604HVM": "ami-67973709"
             },
             "ap-south-1": {
                 "AMZNLINUXHVM": "ami-fedb8f91",
                 "CENTOS7HVM": "ami-82a3eaed",
                 "US1404HVM": "ami-feb4fc91",
-                "US1604HVM": "ami-84dc94eb"
+                "US1604HVM": "ami-5d055232"
             },
             "ap-southeast-1": {
                 "AMZNLINUXHVM": "ami-889cecf4",
                 "CENTOS7HVM": "ami-a6e88dda",
                 "US1404HVM": "ami-2be08157",
-                "US1604HVM": "ami-29aece55"
+                "US1604HVM": "ami-325d2e4e"
             },
             "ap-southeast-2": {
                 "AMZNLINUXHVM": "ami-ccab56ae",
                 "CENTOS7HVM": "ami-5b778339",
                 "US1404HVM": "ami-a458afc6",
-                "US1604HVM": "ami-9b8076f9"
+                "US1604HVM": "ami-37df2255"
             },
             "ca-central-1": {
                 "AMZNLINUXHVM": "ami-61f97c05",
                 "CENTOS7HVM": "ami-b111aad5",
                 "US1404HVM": "ami-72b90316",
-                "US1604HVM": "ami-b0c67cd4"
+                "US1604HVM": "ami-f0870294"
             },
             "eu-central-1": {
                 "AMZNLINUXHVM": "ami-0fc85a60",
                 "CENTOS7HVM": "ami-1e038d71",
                 "US1404HVM": "ami-5231b93d",
-                "US1604HVM": "ami-13b8337c"
+                "US1604HVM": "ami-af79ebc0"
             },
             "eu-west-1": {
                 "AMZNLINUXHVM": "ami-e487179d",
                 "CENTOS7HVM": "ami-192a9460",
                 "US1404HVM": "ami-64b3361d",
-                "US1604HVM": "ami-63b0341a"
+                "US1604HVM": "ami-4d46d534"
             },
             "eu-west-2": {
                 "AMZNLINUXHVM": "ami-51809835",
                 "CENTOS7HVM": "ami-c8d7c9ac",
                 "US1404HVM": "ami-7950491d",
-                "US1604HVM": "ami-22415846"
+                "US1604HVM": "ami-d7aab2b3"
             },
             "sa-east-1": {
                 "AMZNLINUXHVM": "ami-1226647e",
                 "CENTOS7HVM": "ami-6b5c1b07",
                 "US1404HVM": "ami-0f501663",
-                "US1604HVM": "ami-8181c7ed"
+                "US1604HVM": "ami-1157157d"
             },
             "us-east-1": {
                 "AMZNLINUXHVM": "ami-cb9ec1b1",
                 "CENTOS7HVM": "ami-02e98f78",
                 "US1404HVM": "ami-764a210c",
-                "US1604HVM": "ami-3dec9947"
+                "US1604HVM": "ami-5d055232"
             },
             "us-east-2": {
                 "AMZNLINUXHVM": "ami-caaf84af",
                 "CENTOS7HVM": "ami-e0eac385",
                 "US1404HVM": "ami-d36e46b6",
-                "US1604HVM": "ami-597d553c"
+                "US1604HVM": "ami-2581aa40"
             },
             "us-west-1": {
                 "AMZNLINUXHVM": "ami-95eeeef5",
                 "CENTOS7HVM": "ami-b1a59fd1",
                 "US1404HVM": "ami-1e4d497e",
-                "US1604HVM": "ami-1a17137a"
+                "US1604HVM": "ami-79aeae19"
             },
             "us-west-2": {
                 "AMZNLINUXHVM": "ami-32cf7b4a",
                 "CENTOS7HVM": "ami-b63ae0ce",
                 "US1404HVM": "ami-5dcc6a25",
-                "US1604HVM": "ami-a2e544da"
+                "US1604HVM": "ami-1ee65166"
             }
         },
         "LinuxAMINameMap": {


### PR DESCRIPTION
Hello,

I would like to update AMIs for Ubuntu 16.04 for fixing Spectre And Meltdown problem.

Reference: https://wiki.ubuntu.com/SecurityTeam/KnowledgeBase/SpectreAndMeltdown