### PR TITLE
Rewrite of request_eip function; misc cleanup. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scripts/  merge=ours

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.gitattributes

--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -11,7 +11,7 @@ PROGRAM='Linux Bastion'
 function checkos () {
     platform='unknown'
     unamestr=`uname`
-    if [[ "$unamestr" == 'Linux' ]]; then
+    if [[ "${unamestr}" == 'Linux' ]]; then
         platform='linux'
     else
         echo "[WARNING] This script is not supported on MacOS or freebsd"
@@ -20,8 +20,8 @@ function checkos () {
     echo "${FUNCNAME[0]} Ended"
 }
 
-function setup_environment_variables()
-  REGION=$(curl 169.254.169.254/latest/meta-data/placement/availability-zone/)
+function setup_environment_variables() {
+  REGION=$(curl -sq http://169.254.169.254/latest/meta-data/placement/availability-zone/)
     #ex: us-east-1a => us-east-1
   REGION=${REGION: :-1}
 
@@ -29,7 +29,10 @@ function setup_environment_variables()
 
   _userdata=$(curl http://169.254.169.254/latest/user-data/)
 
-  EIP_LIST=$(echo ${_userdata} | grep EIP_LIST)
+  INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+  EIP_LIST=$(echo ${_userdata} | grep EIP_LIST | sed -e 's/EIP_LIST=//g' -e 's/\"//g')
+
+  LOCAL_IP_ADDRESS=$(curl -sq 169.254.169.254/latest/meta-data/network/interfaces/macs/${ETH0_MAC}/local-ipv4s/)
 
   CWG=$(echo ${_userdata} | grep CLOUDWATCHGROUP | sed 's/CLOUDWATCHGROUP=//g')
 
@@ -47,10 +50,12 @@ function setup_environment_variables()
   chmod 770 /tmp/messages
   log_shadow_file_location="${bastion_mnt}/.${bastion_log}"
 
-  export REGION ETHO_MAC EIP_LIST CWG BASTION_MNT BASTION_LOG BASTION_LOGFILE BASTION_LOGFILE_SHADOW
+  export REGION ETHO_MAC EIP_LIST CWG BASTION_MNT BASTION_LOG BASTION_LOGFILE BASTION_LOGFILE_SHADOW \
+          LOCAL_IP_ADDRESS INSTANCE_ID
 }
 
-function usage () {
+
+function usage() {
     echo "$0 <usage>"
     echo " "
     echo "options:"
@@ -73,11 +78,11 @@ function chkstatus () {
 
 function osrelease () {
     OS=`cat /etc/os-release | grep '^NAME=' |  tr -d \" | sed 's/\n//g' | sed 's/NAME=//g'`
-    if [ "$OS" == "Ubuntu" ]; then
+    if [ "${OS}" == "Ubuntu" ]; then
         echo "Ubuntu"
-    elif [ "$OS" == "Amazon Linux AMI" ]; then
+    elif [ "${OS}" == "Amazon Linux AMI" ]; then
         echo "AMZN"
-    elif [ "$OS" == "CentOS Linux" ]; then
+    elif [ "${OS}" == "CentOS Linux" ]; then
         echo "CentOS"
     else
         echo "Operating System Not Found"
@@ -130,7 +135,7 @@ EOF
     chmod a+x /usr/bin/bastion/shell
 
     release=$(osrelease)
-    if [ "$release" == "CentOS" ]; then
+    if [ "${release}" == "CentOS" ]; then
         semanage fcontext -a -t ssh_exec_t /usr/bin/bastion/shell
     fi
 
@@ -164,8 +169,8 @@ EOF
     #Install CloudWatch Log service on AMZN
     yum update -y
     yum install -y awslogs
-    echo "file = $BASTION_LOGFILE_SHADOW" >> /tmp/groupname.txt
-    echo "log_group_name = $CWG" >> /tmp/groupname.txt
+    echo "file = ${BASTION_LOGFILE_SHADOW}" >> /tmp/groupname.txt
+    echo "log_group_name = ${CWG}" >> /tmp/groupname.txt
 
 cat <<'EOF' >> ~/cloudwatchlog.conf
 
@@ -176,14 +181,14 @@ log_stream_name = {instance_id}
 initial_position = start_of_file
 EOF
 
-    LINE=$(cat -n /etc/awslogs/awslogs.conf | grep '\[\/var\/log\/messages\]' | awk {'print $1'})
-    END_LINE=$(echo $(($LINE-1)))
-    head -$END_LINE /etc/awslogs/awslogs.conf > /tmp/awslogs.conf
+    LINE=$(cat -n /etc/awslogs/awslogs.conf | grep '\[\/var\/log\/messages\]' | awk '{print $1}')
+    END_LINE=$(echo $((${LINE}-1)))
+    head -${END_LINE} /etc/awslogs/awslogs.conf > /tmp/awslogs.conf
     cat /tmp/awslogs.conf > /etc/awslogs/awslogs.conf
     cat ~/cloudwatchlog.conf >> /etc/awslogs/awslogs.conf
     cat /tmp/groupname.txt >> /etc/awslogs/awslogs.conf
-    export TMPREGION=`cat /etc/awslogs/awscli.conf | grep region`
-    sed -i.back "s/$TMPREGION/region = $REGION/g" /etc/awslogs/awscli.conf
+    export TMPREGION=$(grep region /etc/awslogs/awscli.conf)
+    sed -i.back "s/${TMPREGION}/region = ${REGION}/g" /etc/awslogs/awscli.conf
 
     #Restart awslogs service
     service awslogs restart
@@ -221,8 +226,8 @@ EOF
     touch /tmp/messages
     chown root:ubuntu /tmp/messages
     #Install CloudWatch logs on Ubuntu
-    echo "file = $BASTION_LOGFILE_SHADOW" >> /tmp/groupname.txt
-    echo "log_group_name = $CWG" >> /tmp/groupname.txt
+    echo "file = ${BASTION_LOGFILE_SHADOW}" >> /tmp/groupname.txt
+    echo "log_group_name = ${CWG}" >> /tmp/groupname.txt
 
 cat <<'EOF' >> ~/cloudwatchlog.conf
 [general]
@@ -238,11 +243,11 @@ EOF
     export DEBIAN_FRONTEND=noninteractive
     apt-get install -y python
     chmod +x ./awslogs-agent-setup.py
-    ./awslogs-agent-setup.py -n -r $REGION -c ~/cloudwatchlog.conf
+    ./awslogs-agent-setup.py -n -r ${REGION} -c ~/cloudwatchlog.conf
 
     #Install Unit file for Ubuntu 16.04
     ubuntu=`cat /etc/os-release | grep VERSION_ID | tr -d \VERSION_ID=\"`
-    if [ "$ubuntu" == "16.04" ]; then
+    if [ "${ubuntu}" == "16.04" ]; then
 cat <<'EOF' >> /etc/systemd/system/awslogs.service
 [Unit]
 Description=The CloudWatch Logs agent
@@ -281,7 +286,7 @@ EOF
 
 function cent_os () {
     echo -e "\nDefaults env_keep += \"SSH_CLIENT\"" >>/etc/sudoers
-    echo -e "#Added by the Linux Bastion Bootstrap\ndeclare -rx IP=$(echo $SSH_CLIENT | awk '{print $1}')" >> /etc/bashrc
+    echo -e "#Added by the Linux Bastion Bootstrap\ndeclare -rx IP=$(echo ${SSH_CLIENT} | awk '{print $1}')" >> /etc/bashrc
 
     echo "declare -rx BASTION_LOG=${BASTION_MNT}/${BASTION_LOG}" >> /etc/bashrc
 
@@ -300,9 +305,9 @@ EOF
 
     # Install CloudWatch Log service on Centos Linux
     centos=`cat /etc/os-release | grep VERSION_ID | tr -d \VERSION_ID=\"`
-    if [ "$centos" == "7" ]; then
-        echo "file = $BASTION_LOGFILE_SHADOW" >> /tmp/groupname.txt
-        echo "log_group_name = $CWG" >> /tmp/groupname.txt
+    if [ "${centos}" == "7" ]; then
+        echo "file = ${BASTION_LOGFILE_SHADOW}" >> /tmp/groupname.txt
+        echo "log_group_name = ${CWG}" >> /tmp/groupname.txt
 
         cat <<- 'EOF' >> ~/cloudwatchlog.conf
         [general]
@@ -321,7 +326,7 @@ EOF
 
         curl https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
         chmod +x ./awslogs-agent-setup.py
-        ./awslogs-agent-setup.py -n -r $REGION -c ~/cloudwatchlog.conf
+        ./awslogs-agent-setup.py -n -r ${REGION} -c ~/cloudwatchlog.conf
         cat <<- 'EOF' >> /etc/systemd/system/awslogs.service
         [Unit]
         Description=The CloudWatch Logs agent
@@ -345,9 +350,9 @@ EOF
         yum update -y
         yum install -y awslogs
         export TMPREGION=`cat /etc/awslogs/awscli.conf | grep region`
-        sed -i.back "s/$TMPREGION/region = $REGION/g" /etc/awslogs/awscli.conf
-        echo "file = $BASTION_LOGFILE_SHADOW" >> /tmp/groupname.txt
-        echo "log_group_name = $CWG" >> /tmp/groupname.txt
+        sed -i.back "s/${TMPREGION}/region = ${REGION}/g" /etc/awslogs/awscli.conf
+        echo "file = ${BASTION_LOGFILE_SHADOW}" >> /tmp/groupname.txt
+        echo "log_group_name = ${CWG}" >> /tmp/groupname.txt
 
         cat <<'EOF' >> ~/cloudwatchlog.conf
         [/var/log/bastion]
@@ -357,13 +362,13 @@ EOF
         initial_position = start_of_file
 EOF
         export TMPGROUP=`cat /etc/awslogs/awslogs.conf | grep ^log_group_name`
-        export TMPGROUP=`echo $TMPGROUP | sed 's/\//\\\\\//g'`
-        sed -i.back "s/$TMPGROUP/log_group_name = $CWG/g" /etc/awslogs/awslogs.conf
+        export TMPGROUP=`echo ${TMPGROUP} | sed 's/\//\\\\\//g'`
+        sed -i.back "s/${TMPGROUP}/log_group_name = ${CWG}/g" /etc/awslogs/awslogs.conf
         cat ~/cloudwatchlog.conf >> /etc/awslogs/awslogs.conf
         cat /tmp/groupname.txt >> /etc/awslogs/awslogs.conf
         yum install ec2-metadata -y
         export TMPREGION=`cat /etc/awslogs/awscli.conf | grep region`
-        sed -i.back "s/$TMPREGION/region = $REGION/g" /etc/awslogs/awscli.conf
+        sed -i.back "s/${TMPREGION}/region = ${REGION}/g" /etc/awslogs/awscli.conf
         sleep 3
         service awslogs stop
         sleep 3
@@ -379,99 +384,65 @@ EOF
 }
 
 function request_eip() {
-    release=$(osrelease)
-    #Check if EIP already assigned.
-    ALLOC=1
-    ZERO=0
-    INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-    ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
-    if [ "$ASSIGNED" -gt "$ZERO" ]; then
-        echo "Already assigned an EIP."
-    else
-        aws ec2 describe-addresses --region $REGION --output text > /query.txt
-        #Ensure we are only using EIPs from our Stack
-        line=`curl http://169.254.169.254/latest/user-data/ | grep EIP_LIST`
-        IFS=$':' DIRS=(${line//$','/:})       # Replace tabs with colons.
 
-        for (( i=0 ; i<${#DIRS[@]} ; i++ )); do
-            EIP=`echo ${DIRS[i]} | sed 's/\"//g' | sed 's/EIP_LIST=//g'`
-            if [ $EIP != "Null" ]; then
-                #echo "$i: $EIP"
-                grep "$EIP" /query.txt >> /query2.txt;
-            fi
-        done
-        mv /query2.txt /query.txt
-
-
-        AVAILABLE_EIPs=`cat /query.txt | wc -l`
-
-        if [ "$AVAILABLE_EIPs" -gt "$ZERO" ]; then
-            FIELD_COUNT="5"
-            INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-            echo "Running associate_eip_now"
-            while read name;
-            do
-                #EIP_ENTRY=$(echo $name | grep eip | wc -l)
-                EIP_ENTRY=$(echo $name | grep eni | wc -l)
-                echo "EIP: $EIP_ENTRY"
-                if [ "$EIP_ENTRY" -eq 1 ]; then
-                    echo "Already associated with an instance"
-                    echo ""
-                else
-                    export EIP=`echo "$name" | sed 's/[\s]+/,/g' | awk {'print $4'}`
-                    EIPALLOC=`echo $name | awk {'print $2'}`
-                    echo "NAME: $name"
-                    echo "EIP: $EIP"
-                    echo "EIPALLOC: $EIPALLOC"
-                    aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIPALLOC --region $REGION
-                fi
-            done < /query.txt
-        else
-            echo "[ERROR] No Elastic IPs available in this region"
-            exit 1
-        fi
-
-        INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-        ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
-        if [ "$ASSIGNED" -eq 1 ]; then
-            echo "EIP successfully assigned."
-        else
-            #Retry
-            while [ "$ASSIGNED" -eq "$ZERO" ]
-            do
-                sleep 3
-                request_eip
-                INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-                ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
-            done
-        fi
+    # Is the already-assigned Public IP an elastic IP?
+    _query_assigned_public_ip
+    _determine_eip_assocation_status ${PUBLIC_IP_ADDRESS}
+    if [[ $? -ne 1 ]]; then
+      echo "The Public IP address associated with eth0 (${PUBLIC_IP_ADDRESS}) is already an Elastic IP. Not proceeding further."
+      exit 1
     fi
+    EIP_ARRAY=(${EIP_LIST//,/ })
+    _eip_assigned_count=0
 
+    for eip in "${EIP_ARRAY[@]}"; do
+      # Determine if the EIP has already been assigned.
+      _determine_eip_assocation_status ${eip}
+      if [[ $? -eq 0 ]]; then
+        echo "Elastic IP [${eip}] already has an association. Moving on."
+        let _eip_assigned_count+=1
+        if [ "${_eip_assigned_count}" -eq "${#EIP_ARRAY[@]}" ]; then
+          echo "All of the stack EIPs have been assigned (${_eip_assigned_count}/${#EIP_ARRAY[@]}). I can't assign anything else. Exiting."
+          exit 1
+        fi
+        continue
+      fi
+
+      _determine_eip_allocation ${eip}
+
+      # Attempt to assign it to the ENI.
+      aws ec2 associate-address --instance-id ${INSTANCE_ID} --allocation-id  ${eip_allocation} --region ${REGION}
+      if [ $? -ne 0 ]; then
+        let _eip_assigned_count+=1
+        continue
+      else
+        echo "The newly-assigned EIP is ${eip}. It is mapped under EIP Allocation ${eip_allocation}"
+        break
+      fi
+    done
     echo "${FUNCNAME[0]} Ended"
 }
 
-function _query_public_v4_ips() {
-  PUBLIC_IP_ADDRESS=$(curl 169.254.169.254/latest/meta-data/public-ipv4/${ETH0_MAC}/public-ipv4s/)
-  return PUBLIC_IP_ADDRESS
+function _query_assigned_public_ip() {
+  # Note: ETH0 Only.
+  # - Does not distinquish between EIP and Standard IP. Need to cross-ref later.
+  PUBLIC_IP_ADDRESS=$(curl -sq 169.254.169.254/latest/meta-data/public-ipv4/${ETH0_MAC}/public-ipv4s/)
 }
 
-function call_request_eip() {
-    ZERO=0
-    INSTANCE_IP=`ifconfig -a | grep inet | awk {'print $2'} | sed 's/addr://g' | head -1`
-    ASSIGNED=$(aws ec2 describe-addresses --region $REGION --output text | grep $INSTANCE_IP | wc -l)
-    if [ "$ASSIGNED" -gt 0 ]; then
-        echo "Already assigned an EIP."
-    else
-        WAIT=$(shuf -i 1-30 -n 1)
-        sleep "$WAIT"
-        request_eip
-    fi
-    echo "${FUNCNAME[0]} Ended"
+function _determine_eip_assocation_status(){
+  aws ec2 describe-addresses --public-ips ${1} --output text --region ${REGION}  | grep -o -i eipassoc -q
+  if [[ $? -eq 0 ]]; then
+    return 0
+  fi
+  return 1
+}
+
+function _determine_eip_allocation(){
+  eip_allocation=$(aws ec2 describe-addresses --public-ips ${1} --output text --region ${REGION}| egrep 'eipalloc-([a-z0-9]{8})' -o)
 }
 
 function prevent_process_snooping() {
     # Prevent bastion host users from viewing processes owned by other users.
-
     mount -o remount,rw,hidepid=2 /proc
     awk '!/proc/' /etc/fstab > temp && mv temp /etc/fstab
     echo "proc /proc proc defaults,hidepid=2 0 0" >> /etc/fstab
@@ -482,6 +453,7 @@ function prevent_process_snooping() {
 
 # Call checkos to ensure platform is Linux
 checkos
+# Assuming it is, setup environment variables.
 setup_environment_variables
 
 ## set an initial value
@@ -489,7 +461,7 @@ SSH_BANNER="LINUX BASTION"
 
 # Read the options from cli input
 TEMP=`getopt -o h:  --long help,banner:,enable:,tcp-forwarding:,x11-forwarding: -n $0 -- "$@"`
-eval set -- "$TEMP"
+eval set -- "${TEMP}"
 
 
 if [ $# == 1 ] ; then echo "No input provided! type ($0 --help) to see usage help" >&2 ; exit 1 ; fi
@@ -528,7 +500,7 @@ done
 
 # BANNER CONFIGURATION
 BANNER_FILE="/etc/ssh_banner"
-if [[ $ENABLE == "true" ]];then
+if [[ ${ENABLE} == "true" ]];then
     if [ -z ${BANNER_PATH} ];then
         echo "BANNER_PATH is null skipping ..."
     else
@@ -536,7 +508,7 @@ if [[ $ENABLE == "true" ]];then
         echo "Creating Banner in ${BANNER_FILE}"
         echo "curl  -s ${BANNER_PATH} > ${BANNER_FILE}"
         curl  -s ${BANNER_PATH} > ${BANNER_FILE}
-        if [ $BANNER_FILE ] ;then
+        if [ ${BANNER_FILE} ] ;then
             echo "[INFO] Installing banner ... "
             echo -e "\n Banner ${BANNER_FILE}" >>/etc/ssh/sshd_config
         else
@@ -549,37 +521,35 @@ else
 fi
 
 #Enable/Disable TCP forwarding
-TCP_FORWARDING=`echo "$TCP_FORWARDING" | sed 's/\\n//g'`
+TCP_FORWARDING=`echo "${TCP_FORWARDING}" | sed 's/\\n//g'`
 
 #Enable/Disable X11 forwarding
-X11_FORWARDING=`echo "$X11_FORWARDING" | sed 's/\\n//g'`
+X11_FORWARDING=`echo "${X11_FORWARDING}" | sed 's/\\n//g'`
 
-echo "Value of TCP_FORWARDING - $TCP_FORWARDING"
-
-echo "Value of X11_FORWARDING - $X11_FORWARDING"
-
-if [[ $TCP_FORWARDING == "false" ]];then
+echo "Value of TCP_FORWARDING - ${TCP_FORWARDING}"
+echo "Value of X11_FORWARDING - ${X11_FORWARDING}"
+if [[ ${TCP_FORWARDING} == "false" ]];then
     awk '!/AllowTcpForwarding/' /etc/ssh/sshd_config > temp && mv temp /etc/ssh/sshd_config
     echo "AllowTcpForwarding no" >> /etc/ssh/sshd_config
     harden_ssh_security
 fi
 
-if [[ $X11_FORWARDING == "false" ]];then
+if [[ ${X11_FORWARDING} == "false" ]];then
     awk '!/X11Forwarding/' /etc/ssh/sshd_config > temp && mv temp /etc/ssh/sshd_config
     echo "X11Forwarding no" >> /etc/ssh/sshd_config
 fi
 
 release=$(osrelease)
 # Ubuntu Linux
-if [ "$release" == "Ubuntu" ]; then
+if [ "${release}" == "Ubuntu" ]; then
     #Call function for Ubuntu
     ubuntu_os
 # AMZN Linux
-elif [ "$release" == "AMZN" ]; then
+elif [ "${release}" == "AMZN" ]; then
     #Call function for AMZN
     amazon_os
 # CentOS Linux
-elif [ "$release" == "CentOS" ]; then
+elif [ "${release}" == "CentOS" ]; then
     #Call function for CentOS
     cent_os
 else
@@ -588,6 +558,6 @@ else
 fi
 
 prevent_process_snooping
-call_request_eip
+request_eip
 
 echo "Bootstrap complete."

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -229,97 +229,97 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "AMZNLINUXHVM": "amzn-ami-hvm-2017.09.1.20180108-x86_64-gp2",
+                "AMZNLINUXHVM": "amzn-ami-hvm-2017.09.1.20180115-x86_64-gp2",
                 "CENTOS7HVM": "CentOS Linux 7 x86_64 HVM EBS 1708_11.01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-95096eef.4",
                 "US1404HVM": "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20180110",
                 "US1604HVM": "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20180109"
             },
             "ap-northeast-1": {
-                "AMZNLINUXHVM": "ami-33c25b55",
+                "AMZNLINUXHVM": "ami-ceafcba8",
                 "CENTOS7HVM": "ami-4dd5522b",
                 "US1404HVM": "ami-816cf4e7",
                 "US1604HVM": "ami-d39a02b5"
             },
             "ap-northeast-2": {
-                "AMZNLINUXHVM": "ami-d9b616b7",
+                "AMZNLINUXHVM": "ami-863090e8",
                 "CENTOS7HVM": "ami-53a1073d",
                 "US1404HVM": "ami-7246e61c",
                 "US1604HVM": "ami-67973709"
             },
             "ap-south-1": {
-                "AMZNLINUXHVM": "ami-fedb8f91",
+                "AMZNLINUXHVM": "ami-531a4c3c",
                 "CENTOS7HVM": "ami-82a3eaed",
                 "US1404HVM": "ami-2390c74c",
                 "US1604HVM": "ami-5d055232"
             },
             "ap-southeast-1": {
-                "AMZNLINUXHVM": "ami-889cecf4",
+                "AMZNLINUXHVM": "ami-68097514",
                 "CENTOS7HVM": "ami-a6e88dda",
                 "US1404HVM": "ami-1384f76f",
                 "US1604HVM": "ami-325d2e4e"
             },
             "ap-southeast-2": {
-                "AMZNLINUXHVM": "ami-ccab56ae",
+                "AMZNLINUXHVM": "ami-942dd1f6",
                 "CENTOS7HVM": "ami-5b778339",
                 "US1404HVM": "ami-c831ccaa",
                 "US1604HVM": "ami-37df2255"
             },
             "ca-central-1": {
-                "AMZNLINUXHVM": "ami-61f97c05",
+                "AMZNLINUXHVM": "ami-a954d1cd",
                 "CENTOS7HVM": "ami-b111aad5",
                 "US1404HVM": "ami-ccaf2aa8",
                 "US1604HVM": "ami-f0870294"
             },
             "eu-central-1": {
-                "AMZNLINUXHVM": "ami-0fc85a60",
+                "AMZNLINUXHVM": "ami-5652ce39",
                 "CENTOS7HVM": "ami-1e038d71",
                 "US1404HVM": "ami-a531a3ca",
                 "US1604HVM": "ami-af79ebc0"
             },
             "eu-west-1": {
-                "AMZNLINUXHVM": "ami-e487179d",
+                "AMZNLINUXHVM": "ami-d834aba1",
                 "CENTOS7HVM": "ami-192a9460",
                 "US1404HVM": "ami-34f2604d",
                 "US1604HVM": "ami-4d46d534"
             },
             "eu-west-2": {
-                "AMZNLINUXHVM": "ami-51809835",
+                "AMZNLINUXHVM": "ami-403e2524",
                 "CENTOS7HVM": "ami-c8d7c9ac",
                 "US1404HVM": "ami-606b7004",
                 "US1604HVM": "ami-d7aab2b3"
             },
             "eu-west-3": {
-                "AMZNLINUXHVM": "ami-fe03b483",
+                "AMZNLINUXHVM": "ami-8ee056f3",
                 "CENTOS7HVM": "ami-0c60d771",
                 "US1404HVM": "ami-03fd4b7e",
                 "US1604HVM": "ami-5e0eb923"
             },
             "sa-east-1": {
-                "AMZNLINUXHVM": "ami-1226647e",
+                "AMZNLINUXHVM": "ami-84175ae8",
                 "CENTOS7HVM": "ami-6b5c1b07",
                 "US1404HVM": "ami-926527fe",
                 "US1604HVM": "ami-1157157d"
             },
             "us-east-1": {
-                "AMZNLINUXHVM": "ami-cb9ec1b1",
+                "AMZNLINUXHVM": "ami-97785bed",
                 "CENTOS7HVM": "ami-02e98f78",
                 "US1404HVM": "ami-33e4bc49",
                 "US1604HVM": "ami-41e0b93b"
             },
             "us-east-2": {
-                "AMZNLINUXHVM": "ami-caaf84af",
+                "AMZNLINUXHVM": "ami-f63b1193",
                 "CENTOS7HVM": "ami-e0eac385",
                 "US1404HVM": "ami-854b61e0",
                 "US1604HVM": "ami-2581aa40"
             },
             "us-west-1": {
-                "AMZNLINUXHVM": "ami-95eeeef5",
+                "AMZNLINUXHVM": "ami-824c4ee2",
                 "CENTOS7HVM": "ami-b1a59fd1",
                 "US1404HVM": "ami-915f5cf1",
                 "US1604HVM": "ami-79aeae19"
             },
             "us-west-2": {
-                "AMZNLINUXHVM": "ami-32cf7b4a",
+                "AMZNLINUXHVM": "ami-f2d3638a",
                 "CENTOS7HVM": "ami-b63ae0ce",
                 "US1404HVM": "ami-b88c3bc0",
                 "US1604HVM": "ami-1ee65166"


### PR DESCRIPTION

Fixes: https://github.com/aws-quickstart/quickstart-linux-bastion/issues/21
Potentially makes redundant: https://github.com/aws-quickstart/quickstart-linux-bastion/pull/18

[Shell debugging output in the following scenarios](https://gist.github.com/agamzn/91755b132307cd4a0bdbc8db34c9d749): 
- Assigns the EIP at first attempt. 
- Assigns the EIP after multiple Attempts
- No EIPs available to assign. 
- EIP Is already assigned. 

[Confirmed taskcat runs in us-east-1](https://gist.github.com/agamzn/e6c08855d9600808aba265c7e9e21885). 
- Note: I'm hitting VPC limits in other regions, so elected us-east-1 as a quicker sanity check. I'm happy to spawn off in other regions if requested, but for the moment, don't see it as strictly necessary. 