### PR TITLE
QSS3KeyPrefix should end with a '/'

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -200,10 +200,10 @@
             "Type": "String"
         },
         "QSS3KeyPrefix": {
-            "AllowedPattern": "^[0-9a-zA-Z-/]*$",
-            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).",
+            "AllowedPattern": "^([0-9a-zA-Z-]+/)*$",
+            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/). The prefix should end with a forward slash (/).",
             "Default": "quickstart-linux-bastion/",
-            "Description": "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).",
+            "Description": "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/) and it should end with a forward slash (/).",
             "Type": "String"
         },
         "RemoteAccessCIDR": {


### PR DESCRIPTION
If it doesn't, the bastion host cannot find its init script and subsequently the stack cannot boot.