### PR TITLE
Fix for exporting ETH0_MAC

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -50,7 +50,7 @@ function setup_environment_variables() {
   chmod 770 /tmp/messages
   log_shadow_file_location="${bastion_mnt}/.${bastion_log}"
 
-  export REGION ETHO_MAC EIP_LIST CWG BASTION_MNT BASTION_LOG BASTION_LOGFILE BASTION_LOGFILE_SHADOW \
+  export REGION ETH0_MAC EIP_LIST CWG BASTION_MNT BASTION_LOG BASTION_LOGFILE BASTION_LOGFILE_SHADOW \
           LOCAL_IP_ADDRESS INSTANCE_ID
 }
 


### PR DESCRIPTION
Value exported in function setup_environment_variables (ETHO_MAC; with capital "o") is suppose to be used in function  _query_assigned_public_ip as ETH0_MAC (with 0).