### PR TITLE
Possibility to change SSH port to different than 22

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -70,6 +70,7 @@ function usage() {
     echo -e "--enable \t SSH Banner"
     echo -e "--tcp-forwarding \t Enable or Disable TCP Forwarding"
     echo -e "--x11-forwarding \t Enable or Disable X11 Forwarding"
+    echo -e "--ssh-port \t Use different SSH port"
 }
 
 function chkstatus () {
@@ -539,6 +540,10 @@ while true; do
             X11_FORWARDING="$2";
             shift 2
             ;;
+        --ssh-port)
+            SSH_NEW_PORT="$2";
+            shift 2
+            ;;
         --)
             break
             ;;
@@ -576,8 +581,13 @@ TCP_FORWARDING=`echo "${TCP_FORWARDING}" | sed 's/\\n//g'`
 #Enable/Disable X11 forwarding
 X11_FORWARDING=`echo "${X11_FORWARDING}" | sed 's/\\n//g'`
 
+#Change SSH port from default 22
+SSH_NEW_PORT=`echo "${SSH_NEW_PORT}" | sed 's/\\n//g'`
+
 echo "Value of TCP_FORWARDING - ${TCP_FORWARDING}"
 echo "Value of X11_FORWARDING - ${X11_FORWARDING}"
+echo "Value of SSH_NEW_PORT - ${SSH_NEW_PORT}"
+
 if [[ ${TCP_FORWARDING} == "false" ]];then
     awk '!/AllowTcpForwarding/' /etc/ssh/sshd_config > temp && mv temp /etc/ssh/sshd_config
     echo "AllowTcpForwarding no" >> /etc/ssh/sshd_config
@@ -587,6 +597,11 @@ fi
 if [[ ${X11_FORWARDING} == "false" ]];then
     awk '!/X11Forwarding/' /etc/ssh/sshd_config > temp && mv temp /etc/ssh/sshd_config
     echo "X11Forwarding no" >> /etc/ssh/sshd_config
+fi
+
+if [[ ${SSH_NEW_PORT} != "" ]];then
+    awk '!/Port/' /etc/ssh/sshd_config > temp && mv temp /etc/ssh/sshd_config
+    echo "Port ${SSH_NEW_PORT}" >> /etc/ssh/sshd_config
 fi
 
 release=$(osrelease)

--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -298,12 +298,12 @@ EOF
 
 function cent_os () {
     echo -e "\nDefaults env_keep += \"SSH_CLIENT\"" >>/etc/sudoers
-    echo -e "#Added by the Linux Bastion Bootstrap\ndeclare -rx IP=$(echo ${SSH_CLIENT} | awk '{print $1}')" >> /etc/bashrc
+    echo -e "#Added by the Linux Bastion Bootstrap\ndeclare -rx IP=\$(echo \${SSH_CLIENT} | awk '{print \$1}')" >> /etc/bashrc
 
     echo "declare -rx BASTION_LOG=${BASTION_MNT}/${BASTION_LOG}" >> /etc/bashrc
 
     cat <<- EOF >> /etc/bashrc
-    declare -rx PROMPT_COMMAND='history -a >(logger -t "ON: $(date)   [FROM]:${IP}   [USER]:${USER}   [PWD]:${PWD}" -s 2>>${BASTION_LOG})'
+    declare -rx PROMPT_COMMAND='history -a >(logger -t "[ON]: $(date)   [FROM]:${IP}   [USER]:${USER}   [PWD]:${PWD}" -s 2>>${BASTION_LOG})'
 EOF
 
     chown root:centos ${BASTION_MNT}

--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -39,7 +39,8 @@
                         "EnableBanner",
                         "BastionBanner",
                         "EnableTCPForwarding",
-                        "EnableX11Forwarding"
+                        "EnableX11Forwarding",
+                        "SSHPort"
                     ]
                 },
                 {
@@ -76,6 +77,9 @@
                 },
                 "EnableX11Forwarding": {
                     "default": "Enable X11 Forwarding"
+                },
+                "SSHPort": {
+                    "default": "Port for SSH"
                 },
                 "KeyPairName": {
                     "default": "Key Pair Name"
@@ -188,6 +192,11 @@
                 "true",
                 "false"
             ]
+        },
+        "SSHPort": {
+            "Type": "Number",
+            "Description": "Port used by SSH",
+            "Default": "22"
         },
         "KeyPairName": {
             "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
@@ -370,6 +379,9 @@
                     },
                     "EnableX11Forwarding": {
                         "Ref": "EnableX11Forwarding"
+                    },
+                    "SSHPort": {
+                        "Ref": "SSHPort"
                     },
                     "KeyPairName": {
                         "Ref": "KeyPairName"

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -35,7 +35,8 @@
                         "EnableBanner",
                         "BastionBanner",
                         "EnableTCPForwarding",
-                        "EnableX11Forwarding"
+                        "EnableX11Forwarding",
+                        "SSHPort"
                     ]
                 },
                 {
@@ -69,6 +70,9 @@
                 },
                 "EnableX11Forwarding": {
                     "default": "Enable X11 Forwarding"
+                },
+                "SSHPort": {
+                    "default": "Port for SSH"
                 },
                 "KeyPairName": {
                     "default": "Key Pair Name"
@@ -168,6 +172,11 @@
                 "true",
                 "false"
             ]
+        },
+        "SSHPort": {
+            "Type": "Number",
+            "Description": "Port used by SSH",
+            "Default": "22"
         },
         "KeyPairName": {
             "Description": "Enter a Public/private key pair. If you do not have one in this region, please create it before continuing",
@@ -756,6 +765,10 @@
                                             " --x11-forwarding ",
                                             {
                                                 "Ref": "EnableX11Forwarding"
+                                            },
+                                            " --ssh-port ",
+                                            {
+                                                "Ref": "SSHPort"
                                             }
                                         ]
                                     ]


### PR DESCRIPTION
By default it will leave port 22. But to avoid unnecessary login attempts from harvesters allow to change it to something different (above 1024).

In this PR there is also one commit that somehow wasn't merged in my previous PRs.
It fixes logging IP value and using same format for all fields in bastion.log.