### PR TITLE
add SSM managed policy

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -537,6 +537,11 @@
                         }
                     ],
                     "Version": "2012-10-17"
+                },
+                {
+                    "ManagedPolicyArns": [
+                        "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-quickstart/quickstart-amazon-eks/issues/17

*Description of changes:*

Adds the SSM managed policy to the bastion so that users can use ssm to manage the bastion after it;s launch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
