### PR TITLE
Add t3 instance types

### DIFF
--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -109,6 +109,12 @@ Parameters:
       - t2.small
       - t2.medium
       - t2.large
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
       - m3.large
       - m3.xlarge
       - m3.2xlarge

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -94,6 +94,12 @@ Parameters:
       - t2.small
       - t2.medium
       - t2.large
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
       - m3.large
       - m3.xlarge
       - m3.2xlarge


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-quickstart/quickstart-bitnami-wordpress/issues/35

*Description of changes:*

This PR adds the `t3` instance type family to the `AllowedValues`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
