### PR TITLE
Remove deprecated policy AmazonEC2RoleforSSM

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -443,7 +443,8 @@ Resources:
             Effect: Allow
         Version: 2012-10-17
       ManagedPolicyArns:
-        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
   BastionHostPolicy:
     Type: 'AWS::IAM::Policy'
     Properties:


### PR DESCRIPTION
*Issue #, if available:*

Remove deprecated policy AmazonEC2RoleforSSM

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
