### PR TITLE
Added default value for URL_SUFFIX

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -154,6 +154,7 @@ EOF
 function setup_logs () {
 
     echo "${FUNCNAME[0]} Started"
+    URL_SUFFIX="${URL_SUFFIX:-amazonaws.com}"
 
     if [[ "${release}" == "SLES" ]]; then
         curl "https://amazoncloudwatch-agent-${REGION}.s3.${REGION}.${URL_SUFFIX}/suse/amd64/latest/amazon-cloudwatch-agent.rpm" -O


### PR DESCRIPTION
*Issue #, if available:*
#90 

*Description of changes:*
The recent change to accept a URL_SUFFIX variable is not backwards compatible. This fix sets the default value to match the previous version of the script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
