### PR TITLE
Make use of the 'env' key when running the bootstrap script.

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -595,15 +595,18 @@ Resources:
           commands:
             b-bootstrap:
               cwd: '/tmp/'
+              env:
+                REGION: !Sub ${AWS::Region}
+                URL_SUFFIX: !Sub ${AWS::URLSuffix}
+                BANNER_REGION: !If [ UsingDefaultBucket, !Ref 'AWS::Region', !Ref 'QSS3BucketRegion' ]
               command: !Sub
-                - "REGION=${AWS::Region} URL_SUFFIX=${AWS::URLSuffix} BANNER_REGION=${BannerRegion} ./bastion_bootstrap.sh --banner ${BannerUrl} --enable ${EnableBanner} --tcp-forwarding ${EnableTCPForwarding} --x11-forwarding ${EnableX11Forwarding}"
-                - BannerRegion: !If [ UsingDefaultBucket, !Ref 'AWS::Region', !Ref 'QSS3BucketRegion' ]
-                  BannerUrl: !If
-                    - DefaultBanner
-                    - !Sub
-                      - s3://${S3Bucket}/${QSS3KeyPrefix}scripts/banner_message.txt
-                      - S3Bucket: !If [ UsingDefaultBucket, !Sub 'aws-quickstart-${AWS::Region}', !Ref 'QSS3BucketName' ]
-                    - !Ref BastionBanner
+                - "./bastion_bootstrap.sh --banner ${BannerUrl} --enable ${EnableBanner} --tcp-forwarding ${EnableTCPForwarding} --x11-forwarding ${EnableX11Forwarding}"
+                - BannerUrl: !If
+                  - DefaultBanner
+                  - !Sub
+                    - s3://${S3Bucket}/${QSS3KeyPrefix}scripts/banner_message.txt
+                    - S3Bucket: !If [ UsingDefaultBucket, !Sub 'aws-quickstart-${AWS::Region}', !Ref 'QSS3BucketName' ]
+                  - !Ref BastionBanner
     Properties:
       AssociatePublicIpAddress: true
       PlacementTenancy: !Ref BastionTenancy


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running an official Amazon Linux2 AMI the Init script fails when trying to launch the bootstrap script:
`2020-05-12 10:20:51,548 P21555 [INFO] -----------------------Command Output-----------------------
2020-05-12 10:20:51,548 P21555 [INFO] 	/bin/sh: REGION=us-east-1 URL_SUFFIX=amazonaws.com ./bastion_bootstrap.sh --tcp-forwarding true --x11-forwarding true: No such file or directory`

For some reason the shell was not acknowledging the env vars passed to the script and was processing them as files hence the 'No such file or directory' error (bastion_bootstrap.sh is present under /tmp)

My suggestion is to move the variables under the 'env' key.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
