### PR TITLE
remove leading space in sshd banner config

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -426,7 +426,7 @@ if [[ ${ENABLE} == "true" ]];then
         aws s3 cp "${BANNER_PATH}" "${BANNER_FILE}"  --region ${BANNER_REGION}
         if [[ -e ${BANNER_FILE} ]] ;then
             echo "[INFO] Installing banner ... "
-            echo -e "\n Banner ${BANNER_FILE}" >>/etc/ssh/sshd_config
+            echo -e "\nBanner ${BANNER_FILE}" >>/etc/ssh/sshd_config
         else
             echo "[INFO] banner file is not accessible skipping ..."
             exit 1;


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-quickstart/quickstart-linux-bastion/issues/95

**Description of changes:** A leading space in the configuration of the custom banner prevents the correct configuration of that feature


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
