### PR TITLE
Remove t2.* instances due to lack of consistency

### DIFF
--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -112,13 +112,8 @@ Parameters:
   BastionInstanceType:
     Description: Amazon EC2 instance type for the bastion instances.
     Type: String
-    Default: t2.micro
+    Default: t3.micro
     AllowedValues:
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
       - t3.micro
       - t3.small
       - t3.medium


### PR DESCRIPTION
Some regions actually don't have t2 instances so the script causes issues. eu-north-1 for example. In fact, eu-north-1 doesn't even have m3.* or m4.* support. Only m5.* and above. t3 appears cheaper than t2 in most cases (that I have checked).
>-)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
