### PR TITLE
Remove t2.* instances due to lack of consistency

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -114,11 +114,6 @@ Parameters:
       - default
   BastionInstanceType:
     AllowedValues:
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
       - t3.micro
       - t3.small
       - t3.medium
@@ -129,7 +124,7 @@ Parameters:
       - m4.xlarge
       - m4.2xlarge
       - m4.4xlarge
-    Default: t2.micro
+    Default: t3.micro
     Description: Amazon EC2 instance type for the bastion instances.
     Type: String
   EnableBanner:


### PR DESCRIPTION
Some regions actually don't have t2 instances so the script causes issues. eu-north-1 for example. In fact, eu-north-1 doesn't even have m3.* or m4.* support. Only m5.* and above. t3 appears cheaper than t2 in most cases (that I have checked).
>-)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
