### PR TITLE
fixing audit log file reference

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -128,7 +128,7 @@ function setup_logs () {
             "files": {
                 "collect_list": [
                     {
-                        "file_path": "/var/log/auditd/auditd.log",
+                        "file_path": "/var/log/audit/audit.log",
                         "log_group_name": "${CWG}",
                         "log_stream_name": "{instance_id}",
                         "timestamp_format": "%Y-%m-%d %H:%M:%S",


### PR DESCRIPTION
*Issue #, if available:*
#108

*Description of changes:*
Changing the cloudwatch collect list to reference the file that `auditd` uses: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/security_guide/sec-starting_the_audit_service

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
