### PR TITLE
Use QSS3BucketName to define Bucket Names in more consistent way

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -553,7 +553,7 @@ Resources:
                 - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/auditing_configure.sh
                 - S3Bucket: !If
                     - UsingDefaultBucket
-                    - !Sub 'aws-quickstart-${AWS::Region}'
+                    - !Sub '${QSS3BucketName}-${AWS::Region}'
                     - !Ref 'QSS3BucketName'
                   S3Region: !If
                     - UsingDefaultBucket
@@ -571,7 +571,7 @@ Resources:
                   - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}scripts/bastion_bootstrap.sh
                   - S3Bucket: !If
                       - UsingDefaultBucket
-                      - !Sub 'aws-quickstart-${AWS::Region}'
+                      - !Sub '${QSS3BucketName}-${AWS::Region}'
                       - !Ref 'QSS3BucketName'
                     S3Region: !If
                       - UsingDefaultBucket
@@ -602,7 +602,7 @@ Resources:
                   - DefaultBanner
                   - !Sub
                     - s3://${S3Bucket}/${QSS3KeyPrefix}scripts/banner_message.txt
-                    - S3Bucket: !If [ UsingDefaultBucket, !Sub 'aws-quickstart-${AWS::Region}', !Ref 'QSS3BucketName' ]
+                    - S3Bucket: !If [ UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref 'QSS3BucketName' ]
                   - !Ref BastionBanner
     Properties:
       AssociatePublicIpAddress: true


### PR DESCRIPTION
*Description of changes:*
Bucket names (`buckets`, `S3Bucket`) are determined using different ways, like e.g.:
* Lines 453, 540
  * `!If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]`
* Lines 554...557, 572...575, 605
  * `!If [UsingDefaultBucket, !Sub 'aws-quickstart-${AWS::Region}', !Ref 'QSS3BucketName'`

While `UsingDefaultBucket` ensure that `QSS3BucketName` is `aws-quickstart`