### PR TITLE
Strip double quotes CLOUDWATCHGROUP

### DIFF
--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -46,7 +46,7 @@ function setup_environment_variables() {
 
     LOCAL_IP_ADDRESS=$(imds_request meta-data/network/interfaces/macs/${ETH0_MAC}/local-ipv4s/)
 
-    CWG=$(grep CLOUDWATCHGROUP ${_userdata_file} | sed 's/CLOUDWATCHGROUP=//g')
+    CWG=$(grep CLOUDWATCHGROUP ${_userdata_file} | sed 's/CLOUDWATCHGROUP=//g' -e 's/\"//g')
 
 
     export REGION ETH0_MAC EIP_LIST CWG LOCAL_IP_ADDRESS INSTANCE_ID


### PR DESCRIPTION
Strip double quotes CLOUDWATCHGROUP, similar to EIP_LIST in
bastion_bootstrap.sh script.

*Issue #, if available: #134 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
