### PR TITLE
Add condition to IAM Policy to match Role Condition

### DIFF
--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -527,6 +527,7 @@ Resources:
         - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy'
   BastionHostPolicy:
     Type: 'AWS::IAM::Policy'
+    Condition: CreateIAMRole
     Properties:
       PolicyName: BastionPolicy
       PolicyDocument:
@@ -566,7 +567,6 @@ Resources:
           - !Ref BastionHostRole
           - !Ref AlternativeIAMRole
   BastionHostProfile:
-    DependsOn: BastionHostPolicy
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
       Roles:
@@ -574,7 +574,10 @@ Resources:
           - CreateIAMRole
           - !Ref BastionHostRole
           - !Ref AlternativeIAMRole
-      Path: /
+      Path: !If
+          - CreateIAMRole
+          - /
+          - /account-managed/
   EIP1:
     Type: 'AWS::EC2::EIP'
     Properties:


### PR DESCRIPTION
*Description of changes:*
The user is able to pass in a reference to an existing IAM Role as an
alternative to creating one; a Policy was always created and attached to
the role whether created or supplied. With this change, the passed role
is assumed to have requisite policies already attached so that no IAM
resources are created if the Role is passed by reference.

Additionally, the InstanceProfile is tagged with the /account-managed/
path if created alongside a pre-existing Role to facilitate tracking

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
