### PR TITLE
Add ssm only access mode and remove Instance type restrictions

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -112,7 +112,6 @@ tests:
       - eu-west-1
       - us-east-1
   onlyssmaccess:
-    #Simply leaves RemoteAccessCIDR blank to avoid adding port 22 to SG
     parameters:
       BastionAMIOS: Amazon-Linux2-HVM-ARM
       BastionInstanceType: t4g.nano

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -34,7 +34,6 @@ project:
     PublicSubnet1CIDR: 10.0.128.0/20
     PublicSubnet2CIDR: 10.0.144.0/20
     QSS3BucketName: $[taskcat_autobucket]
-    RemoteAccessCIDR: 10.0.0.0/16
     VPCCIDR: 10.0.0.0/16
     QSS3BucketRegion: $[taskcat_current_region]
 tests:
@@ -42,6 +41,7 @@ tests:
     parameters:
       BastionAMIOS: Amazon-Linux2-HVM
       BastionInstanceType: t3.medium
+      RemoteAccessCIDR: 10.0.0.0/16
     regions:
       - ap-northeast-1
       - ap-northeast-2
@@ -67,6 +67,7 @@ tests:
     parameters:
       BastionAMIOS: CentOS-7-HVM
       BastionInstanceType: t3.medium
+      RemoteAccessCIDR: 10.0.0.0/16
     regions:
       - ap-south-1
       - ca-central-1
@@ -78,6 +79,7 @@ tests:
     parameters:
       BastionAMIOS: SUSE-SLES-15-HVM
       BastionInstanceType: t3.medium
+      RemoteAccessCIDR: 10.0.0.0/16
     regions:
       - ap-south-1
       - ca-central-1
@@ -89,6 +91,7 @@ tests:
     parameters:
       BastionAMIOS: Ubuntu-Server-20.04-LTS-HVM
       BastionInstanceType: t3.medium
+      RemoteAccessCIDR: 10.0.0.0/16
     regions:
       - ap-south-1
       - ca-central-1
@@ -100,6 +103,7 @@ tests:
     parameters:
       BastionAMIOS: Amazon-Linux2-HVM-ARM
       BastionInstanceType: t4g.nano
+      RemoteAccessCIDR: 10.0.0.0/16
     regions:
       - ap-south-1
       - ca-central-1
@@ -107,3 +111,26 @@ tests:
       - eu-north-1
       - eu-west-1
       - us-east-1
+  onlyssmaccess:
+    #Simply leaves RemoteAccessCIDR blank to avoid adding port 22 to SG
+    parameters:
+      BastionAMIOS: Amazon-Linux2-HVM-ARM
+      BastionInstanceType: t4g.nano
+      RemoteAccessCIDR: 'disabled-onlyssmaccess'
+      NumBastionHosts: 2
+    regions:
+      - ap-south-1
+      - ca-central-1
+      - eu-central-1
+      - eu-north-1
+      - eu-west-1
+      - us-east-1
+      - us-east-2
+  multiplehosts:
+    parameters:
+      BastionAMIOS: Amazon-Linux2-HVM-ARM
+      BastionInstanceType: t4g.nano
+      RemoteAccessCIDR: 10.0.0.0/16
+      NumBastionHosts: 2
+    regions:
+      - eu-west-1

--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -117,32 +117,6 @@ Parameters:
     Description: Amazon EC2 instance type for the bastion instances.
     Type: String
     Default: t2.micro
-    AllowedValues:
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
-      - t4g.nano
-      - t4g.micro
-      - t4g.small
-      - t4g.medium
-      - t4g.large
-      - t4g.xlarge
-      - t4g.2xlarge
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
   EnableBanner:
     AllowedValues:
       - 'true'

--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -217,10 +217,11 @@ Parameters:
     See https://aws-quickstart.github.io/option1.html.'
     Type: String
   RemoteAccessCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    AllowedPattern: ^disabled-onlyssmaccess$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be disabled-onlyssmaccess or in the form x.x.x.x/x
     Description: Allowed CIDR block for external SSH access to the bastions
     Type: String
+    Default: disabled-onlyssmaccess
   VPCCIDR:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28

--- a/templates/linux-bastion-master.template
+++ b/templates/linux-bastion-master.template
@@ -4,7 +4,7 @@ Metadata:
   QuickStartDocumentation:
     EntrypointName: "Launch into a new VPC"
     Order: 1
-  LICENSE: Apache License, Version 2.0 
+  LICENSE: Apache License, Version 2.0
   'AWS::CloudFormation::Interface':
     ParameterGroups:
       - Label:
@@ -185,14 +185,14 @@ Parameters:
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: The Quick Start bucket name can include numbers, lowercase
-      letters, uppercase letters, and hyphens (-). It cannot start or end with a 
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a
       hyphen (-).
     Default: aws-quickstart
-    Description: Name of the S3 bucket for your copy of the Quick Start assets. 
-      Keep the default name unless you are customizing the template. 
-      Changing the name updates code references to point to a new Quick 
-      Start location. This name can include numbers, lowercase letters, 
-      uppercase letters, and hyphens, but do not start or end with a hyphen (-). 
+    Description: Name of the S3 bucket for your copy of the Quick Start assets.
+      Keep the default name unless you are customizing the template.
+      Changing the name updates code references to point to a new Quick
+      Start location. This name can include numbers, lowercase letters,
+      uppercase letters, and hyphens, but do not start or end with a hyphen (-).
       See https://aws-quickstart.github.io/option1.html.
     Type: String
   QSS3KeyPrefix:
@@ -200,20 +200,20 @@ Parameters:
     ConstraintDescription: The Quick Start S3 key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slashes (/).
     Default: quickstart-linux-bastion/
-    Description: S3 key prefix that is used to simulate a directory for your copy of the 
-      Quick Start assets. Keep the default prefix unless you are customizing 
-      the template. Changing this prefix updates code references to point to 
-      a new Quick Start location. This prefix can include numbers, lowercase 
-      letters, uppercase letters, hyphens (-), and forward slashes (/). End with a forward slash. 
-      See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html 
+    Description: S3 key prefix that is used to simulate a directory for your copy of the
+      Quick Start assets. Keep the default prefix unless you are customizing
+      the template. Changing this prefix updates code references to point to
+      a new Quick Start location. This prefix can include numbers, lowercase
+      letters, uppercase letters, hyphens (-), and forward slashes (/). End with a forward slash.
+      See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
       and https://aws-quickstart.github.io/option1.html.
     Type: String
   QSS3BucketRegion:
     Default: 'us-east-1'
-    Description: 'AWS Region where the Quick Start S3 bucket (QSS3BucketName) is 
-    hosted. Keep the default Region unless you are customizing the template. 
-    Changing this Region updates code references to point to a new Quick Start location. 
-    When using your own bucket, specify the Region. 
+    Description: 'AWS Region where the Quick Start S3 bucket (QSS3BucketName) is
+    hosted. Keep the default Region unless you are customizing the template.
+    Changing this Region updates code references to point to a new Quick Start location.
+    When using your own bucket, specify the Region.
     See https://aws-quickstart.github.io/option1.html.'
     Type: String
   RemoteAccessCIDR:
@@ -246,7 +246,7 @@ Resources:
             - !Ref 'AWS::Region'
             - !Ref 'QSS3BucketRegion'
       Parameters:
-        AvailabilityZones: !Join 
+        AvailabilityZones: !Join
           - ','
           - !Ref AvailabilityZones
         NumberOfAZs: '2'
@@ -280,17 +280,17 @@ Resources:
         EnableX11Forwarding: !Ref EnableX11Forwarding
         KeyPairName: !Ref KeyPairName
         NumBastionHosts: !Ref NumBastionHosts
-        PublicSubnet1ID: !GetAtt 
+        PublicSubnet1ID: !GetAtt
           - VPCStack
           - Outputs.PublicSubnet1ID
-        PublicSubnet2ID: !GetAtt 
+        PublicSubnet2ID: !GetAtt
           - VPCStack
           - Outputs.PublicSubnet2ID
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         RemoteAccessCIDR: !Ref RemoteAccessCIDR
-        VPCID: !GetAtt 
+        VPCID: !GetAtt
           - VPCStack
           - Outputs.VPCID
 Outputs:

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -126,29 +126,6 @@ Parameters:
       - dedicated
       - default
   BastionInstanceType:
-    AllowedValues:
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
-      - t3.micro
-      - t3.small
-      - t3.medium
-      - t3.large
-      - t3.xlarge
-      - t3.2xlarge
-      - t4g.nano
-      - t4g.micro
-      - t4g.small
-      - t4g.medium
-      - t4g.large
-      - t4g.xlarge
-      - t4g.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
     Default: t2.micro
     Description: Amazon EC2 instance type for the bastion instances.
     Type: String

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -293,6 +293,11 @@ Mappings:
       US2004HVM: ami-08baf9e3c347b7092
       CENTOS7HVM: ami-05788af9005ef9a93
       SLES15HVM: ami-0741fa1a008af40ad
+    eu-south-1:
+      AMZNLINUX2: ami-08a2aed6e0a6f9c7d
+      US2004HVM: ami-01eec6bdfa20f008e
+      CENTOS7HVM: ami-0a84267606bcea16b
+      SLES15HVM: ami-051cbea0e7660063d
     eu-west-1:
       AMZNLINUX2: ami-07d9160fa81ccffb5
       US2004HVM: ami-0f1d11c92a9467c07

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -172,14 +172,14 @@ Parameters:
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: The Quick Start bucket name can include numbers, lowercase
-      letters, uppercase letters, and hyphens (-). It cannot start or end with a 
+      letters, uppercase letters, and hyphens (-). It cannot start or end with a
       hyphen (-).
     Default: aws-quickstart
-    Description: Name of the S3 bucket for your copy of the Quick Start assets. 
-      Keep the default name unless you are customizing the template. 
-      Changing the name updates code references to point to a new Quick 
-      Start location. This name can include numbers, lowercase letters, 
-      uppercase letters, and hyphens, but do not start or end with a hyphen (-). 
+    Description: Name of the S3 bucket for your copy of the Quick Start assets.
+      Keep the default name unless you are customizing the template.
+      Changing the name updates code references to point to a new Quick
+      Start location. This name can include numbers, lowercase letters,
+      uppercase letters, and hyphens, but do not start or end with a hyphen (-).
       See https://aws-quickstart.github.io/option1.html.
     Type: String
   QSS3BucketRegion:
@@ -191,12 +191,12 @@ Parameters:
     ConstraintDescription: The Quick Start S3 key prefix can include numbers, lowercase letters,
       uppercase letters, hyphens (-), and forward slashes (/).
     Default: quickstart-linux-bastion/
-    Description: S3 key prefix that is used to simulate a directory for your copy of the 
-      Quick Start assets. Keep the default prefix unless you are customizing 
-      the template. Changing this prefix updates code references to point to 
-      a new Quick Start location. This prefix can include numbers, lowercase 
-      letters, uppercase letters, hyphens (-), and forward slashes (/). End with a forward slash. 
-      See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html 
+    Description: S3 key prefix that is used to simulate a directory for your copy of the
+      Quick Start assets. Keep the default prefix unless you are customizing
+      the template. Changing this prefix updates code references to point to
+      a new Quick Start location. This prefix can include numbers, lowercase
+      letters, uppercase letters, hyphens (-), and forward slashes (/). End with a forward slash.
+      See https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
       and https://aws-quickstart.github.io/option1.html.
     Type: String
   RemoteAccessCIDR:

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -200,10 +200,11 @@ Parameters:
       and https://aws-quickstart.github.io/option1.html.
     Type: String
   RemoteAccessCIDR:
-    AllowedPattern: ^$|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be blank or in the form x.x.x.x/x
+    AllowedPattern: ^disabled-onlyssmaccess$|^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be disabled-onlyssmaccess or in the form x.x.x.x/x
     Description: Allowed CIDR block for external SSH access to the bastions.
     Type: String
+    Default: disabled-onlyssmaccess
   VPCID:
     Description: ID of the VPC (e.g., vpc-0343606e).
     Type: 'AWS::EC2::VPC::Id'
@@ -260,6 +261,10 @@ Rules:
             - t4g.small
             - t4g.2xlarge
             - t4g.xlarge
+            - m6g.medium
+            - m6g.large
+            - m6g.xlarge
+            - m6g.2xlarge
           - !Ref 'BastionInstanceType'
         AssertDescription: This instance type must use BastionAMIOS type of Amazon-Linux2-HVM-ARM.
     RuleCondition: !Equals
@@ -433,24 +438,33 @@ Mappings:
 Conditions:
   RolePathProvided: !Not [!Equals ["", !Ref RolePath]]
   PermissionsBoundaryProvided: !Not [!Equals ["", !Ref PermissionsBoundaryArn]]
-  2BastionCondition: !Or
+  2BastionConditionHost: !Or
     - !Equals
       - !Ref NumBastionHosts
       - '2'
     - !Condition 3BastionCondition
     - !Condition 4BastionCondition
-  3BastionCondition: !Or
+  3BastionConditionHost: !Or
     - !Equals
       - !Ref NumBastionHosts
       - '3'
     - !Condition 4BastionCondition
-  4BastionCondition: !Equals
+  4BastionConditionHost: !Equals
     - !Ref NumBastionHosts
     - '4'
+  2BastionCondition: !And
+    - !Condition PopulateRemoteCIDR
+    - !Condition 2BastionConditionHost
+  3BastionCondition: !And
+    - !Condition PopulateRemoteCIDR
+    - !Condition 3BastionConditionHost
+  4BastionCondition: !And
+    - !Condition PopulateRemoteCIDR
+    - !Condition 4BastionConditionHost
   PopulateRemoteCIDR: !Not
     - !Equals
       - !Ref RemoteAccessCIDR
-      - ''
+      - 'disabled-onlyssmaccess'
   UseAlternativeInitialization: !Not
     - !Equals
       - !Ref AlternativeInitializationScript
@@ -553,6 +567,7 @@ Resources:
       Path: /
   EIP1:
     Type: 'AWS::EC2::EIP'
+    Condition: PopulateRemoteCIDR
     Properties:
       Domain: vpc
   EIP2:
@@ -733,7 +748,12 @@ Resources:
             CLOUDWATCHGROUP=${BastionMainLogGroup}
             cfn-init -v --stack '${AWS::StackName}' --resource BastionLaunchConfiguration --region ${AWS::Region} || cfn_fail
             [ $(qs_status) == 0 ] && cfn_success || cfn_fail
-          - EIP2:
+          - EIP1:
+              !If
+              - PopulateRemoteCIDR
+              - !Ref EIP1
+              - 'Null'
+            EIP2:
               !If
               - 2BastionCondition
               - !Ref EIP2
@@ -773,6 +793,7 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-BastionAutoScalingGroup'
   EIP1:
+    Condition: PopulateRemoteCIDR
     Description: Elastic IP 1 for bastion.
     Value: !Ref EIP1
     Export:

--- a/templates/linux-bastion.template
+++ b/templates/linux-bastion.template
@@ -200,8 +200,8 @@ Parameters:
       and https://aws-quickstart.github.io/option1.html.
     Type: String
   RemoteAccessCIDR:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/x
+    AllowedPattern: ^$|(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be blank or in the form x.x.x.x/x
     Description: Allowed CIDR block for external SSH access to the bastions.
     Type: String
   VPCID:
@@ -447,6 +447,10 @@ Conditions:
   4BastionCondition: !Equals
     - !Ref NumBastionHosts
     - '4'
+  PopulateRemoteCIDR: !Not
+    - !Equals
+      - !Ref RemoteAccessCIDR
+      - ''
   UseAlternativeInitialization: !Not
     - !Equals
       - !Ref AlternativeInitializationScript
@@ -750,14 +754,18 @@ Resources:
       GroupDescription: Enables SSH Access to Bastion Hosts
       VpcId: !Ref VPCID
       SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref RemoteAccessCIDR
-        - IpProtocol: icmp
-          FromPort: -1
-          ToPort: -1
-          CidrIp: !Ref RemoteAccessCIDR
+        !If
+          - PopulateRemoteCIDR
+          -
+            - IpProtocol: tcp
+              FromPort: 22
+              ToPort: 22
+              CidrIp: !Ref RemoteAccessCIDR
+            - IpProtocol: icmp
+              FromPort: -1
+              ToPort: -1
+              CidrIp: !Ref RemoteAccessCIDR
+          - !Ref "AWS::NoValue"
 Outputs:
   BastionAutoScalingGroup:
     Description: Auto Scaling group reference ID.


### PR DESCRIPTION
*Issue #, if available:*

1. Added m6g instances to image check assertion for sustained performance testing of an EKS application
2. Setting RemoteAccessCIDR: 'disabled-onlyssmaccess' will
  - be self-documenting of the new mode. Using blank means someone has to do a lot of code spelunking to understand that a blank value actively disables stuff for a better security profile rather than doing nothing. Since CIDR has always been required and providing it does what it always did, this change should not carry the risk of breaking anything.
  - prevent inbound port 22 rule from being added to SG
  - prevent any EIPs from being allocated for bastions
    - tested with 2 bastions for disabled-onlyssmaccess and 2 bastions with it set to a CIDR and it creates and omits the EIPs as expected. SSM access to the instances also works with all these changes.
    - Reducing minimum EIP requirements will be another benefit of disabling external port 22 access to bastions. Failures due to insufficient EIPs with this stack are a primary risk when combined with anything else that wants to create EIPs as well.
3. Added new tests to .taskcat.yml
4. Removes instance type restriction for these reasons:
- I need to have larger bastion hosts for performance testing of a stack.
- Having to replicate and maintain the instancetype list into dependent quickstarts is unnecessary friction on development
- Currently Graviton instances are not enabled and Graviton3 is coming soon - so adding graviton types to a static list seems to continue to propagate a lot of code maintenance across dependencies
 - Having a restricted list of instances in a dependency that is used so broadly seems to create unnecessary code updates (and delays of upbound stacks) when new instance types become available (e.g. Graviton2, Graviton3) or additional ones are desired for other purposes.
 - In addition, any dependent quick starts have to duplicate the allowed list into their code to avoid this quick start bombing if another value is chosen.
 - Pull Requests like these can break many dependent quick starts: https://github.com/aws-quickstart/quickstart-linux-bastion/pull/106/files and there is no notification mechanism that this breaking change in happening.
 - Seems to slow development and cause customer breaking changes all for very little benefit.
 - While bastions should generally be as small as possible to get the job done, the default value seems to do a good enough job of encouraging this practice. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
