### PR TITLE
Retain ssm-user passwordless sudo config

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -82,7 +82,6 @@ tests:
       - ap-south-1
       - us-west-1
       - us-gov-west-1
-      - cn-northwest-1
   us2204hvmarm:
     parameters:
       BastionAMIOS: Ubuntu-Server-22.04-LTS-HVM-ARM

--- a/scripts/bastion_bootstrap.sh
+++ b/scripts/bastion_bootstrap.sh
@@ -197,6 +197,8 @@ setup_ssm() {
   echo "${FUNCNAME[0]} started"
   URL_SUFFIX="${URL_SUFFIX:-amazonaws.com}"
 
+  echo "ssm-user ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/ssm-user
+
   if [[ "${release}" == 'CentOS' ]]; then
     echo 'Installing the AWS Systems Manager (SSM) agent...'
     yum install -y "https://amazon-ssm-${REGION}.s3.${REGION}.${URL_SUFFIX}/latest/linux_${ARCHITECTURE}/amazon-ssm-agent.rpm"


### PR DESCRIPTION
* Closes #149
* https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-ssm-user-permissions.html#ssm-user-permissions-linux
* Relates to:
  * https://github.com/aws-quickstart/quickstart-amazon-eks/issues/415
  * https://github.com/aws-quickstart/quickstart-amazon-eks/pull/471

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
